### PR TITLE
Gs/reattach health components

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -215,7 +215,6 @@ int main(int argc, const char** argv)
 	bool running = true;
 	int frame_counter = 0;
 
-
 	while (running) {
 		new_entity_check(world, scene, system_level);
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -285,12 +285,12 @@ int main(int argc, const char** argv)
 		++frame_counter;
 		if (fps_timer.getElapsedTime().asSeconds() > 0.5f) {
 			float seconds = fps_timer.getElapsedTime().asSeconds();
-			/* printf("FPS: %i (%.1f% render)\n", (int)(frame_counter / seconds), */
-			/* 	100 * (float)( */
-			/* 		render_time.asMicroseconds() */
-			/* 		) / ( */
-			/* 			logic_time.asMicroseconds() + */
-			/* 			render_time.asMicroseconds())); */
+			 //printf("FPS: %i (%.1f% render)\n", (int)(frame_counter / seconds), 
+			 //	100 * (float)( 
+			 //		render_time.asMicroseconds() 
+			 //		) / ( 
+			 //			logic_time.asMicroseconds() + 
+			 //			render_time.asMicroseconds()));
 			/* printf("Logic time  (μs): %d\n",  logic_time.asMicroseconds()); */
 			/* printf("Render time (μs): %d\n", render_time.asMicroseconds()); */
 			fps_timer.restart();

--- a/src/lib-tempo/include/tempo/entity/EntityCreation.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreation.hpp
@@ -28,7 +28,8 @@ typedef struct {
 
 typedef struct {
 	char mesh_name[100];
-	 int health;
+	 int current_health;
+	 int max_health;
 } Destroyable_t;
 
 typedef struct {

--- a/src/lib-tempo/include/tempo/entity/EntityCreation.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreation.hpp
@@ -15,20 +15,20 @@ enum EID {
 };
 
 typedef struct {
-	int foo;
+	int health;
 	// int health;
 	/* char  name[100]; */
 	/* float color[3]; */
 } Player_t;
 
 typedef struct {
-	int foo;
+	int health;
 	// int health;
 } AI_t;
 
 typedef struct {
 	char mesh_name[100];
-	// int health;
+	 int health;
 } Destroyable_t;
 
 typedef struct {

--- a/src/lib-tempo/include/tempo/entity/EntityCreation.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreation.hpp
@@ -15,15 +15,15 @@ enum EID {
 };
 
 typedef struct {
-	int health;
-	// int health;
+	int current_health;
+	int max_health;
 	/* char  name[100]; */
 	/* float color[3]; */
 } Player_t;
 
 typedef struct {
-	int health;
-	// int health;
+	int current_health;
+	int max_health;
 } AI_t;
 
 typedef struct {

--- a/src/lib-tempo/include/tempo/entity/EntityCreationClient.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreationClient.hpp
@@ -25,13 +25,12 @@ anax::Entity newEntity(EntityCreationData data,
                        Ogre::SceneManager* scene,
                        tempo::SystemLevelManager system_gm);
 
-anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health, tempo::SystemLevelManager system_grid_motion);
-anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health);
-anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health, std::string mesh_name);
+anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health, tempo::SystemLevelManager system_grid_motion);
+anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int currrent_health, int max_health);
+anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name);
 anax::Entity newNonDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name);
 
 EntityCreationData dumpEntity(anax::Entity e);
 }
 
 #endif
-

--- a/src/lib-tempo/include/tempo/entity/EntityCreationClient.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreationClient.hpp
@@ -6,7 +6,9 @@
 #include <Ogre.h>
 
 #include <tempo/entity/EntityCreation.hpp>
+#include <tempo/entity/Health.hpp>
 #include <tempo/entity/Render.hpp>
+#include <tempo/entity/RenderHealth.hpp>
 #include <tempo/entity/ID.hpp>
 #include <tempo/entity/LevelManager.hpp>
 #include <tempo/entity/GridAi.hpp>
@@ -23,9 +25,9 @@ anax::Entity newEntity(EntityCreationData data,
                        Ogre::SceneManager* scene,
                        tempo::SystemLevelManager system_gm);
 
-anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, tempo::SystemLevelManager system_grid_motion);
-anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y);
-anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name);
+anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health, tempo::SystemLevelManager system_grid_motion);
+anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health);
+anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health, std::string mesh_name);
 anax::Entity newNonDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name);
 
 EntityCreationData dumpEntity(anax::Entity e);

--- a/src/lib-tempo/include/tempo/entity/EntityCreationClient.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreationClient.hpp
@@ -26,7 +26,7 @@ anax::Entity newEntity(EntityCreationData data,
                        tempo::SystemLevelManager system_gm);
 
 anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health, tempo::SystemLevelManager system_grid_motion);
-anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int currrent_health, int max_health);
+anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health);
 anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name);
 anax::Entity newNonDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name);
 

--- a/src/lib-tempo/include/tempo/entity/EntityCreationClient.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreationClient.hpp
@@ -27,7 +27,7 @@ anax::Entity newEntity(EntityCreationData data,
 
 anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health, tempo::SystemLevelManager system_grid_motion);
 anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health);
-anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name);
+anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health, std::string mesh_name);
 anax::Entity newNonDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name);
 
 EntityCreationData dumpEntity(anax::Entity e);

--- a/src/lib-tempo/include/tempo/entity/EntityCreationServer.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreationServer.hpp
@@ -5,6 +5,7 @@
 
 #include <tempo/entity/EntityCreation.hpp>
 #include <tempo/entity/ID.hpp>
+#include <tempo/entity/Health.hpp>
 #include <tempo/entity/LevelManager.hpp>
 #include <tempo/entity/GridAi.hpp>
 #include <tempo/entity/PlayerRemoteServer.hpp>
@@ -17,8 +18,8 @@ namespace tempo
 EntityCreationData dumpEntity(anax::Entity e);
 
 anax::Entity newPlayer(anax::World& world, EID tid, SystemLevelManager system_grid_motion);
-anax::Entity newAI(anax::World& world, EID tid, int x, int y);
-anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, std::string mesh_name);
+anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health);
+anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int health, std::string mesh_name);
 anax::Entity newNonDestroyable(anax::World& world, EID tid, int x, int y, std::string mesh_name);
 
 }

--- a/src/lib-tempo/include/tempo/entity/EntityCreationServer.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreationServer.hpp
@@ -19,11 +19,9 @@ EntityCreationData dumpEntity(anax::Entity e);
 
 anax::Entity newPlayer(anax::World& world, EID tid, SystemLevelManager system_grid_motion);
 anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health);
-anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int health, std::string mesh_name);
+anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int current_health, int max_health, std::string mesh_name);
 anax::Entity newNonDestroyable(anax::World& world, EID tid, int x, int y, std::string mesh_name);
 
 }
 
 #endif
-
-

--- a/src/lib-tempo/include/tempo/entity/EntityCreationServer.hpp
+++ b/src/lib-tempo/include/tempo/entity/EntityCreationServer.hpp
@@ -18,7 +18,7 @@ namespace tempo
 EntityCreationData dumpEntity(anax::Entity e);
 
 anax::Entity newPlayer(anax::World& world, EID tid, SystemLevelManager system_grid_motion);
-anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health);
+anax::Entity newAI(anax::World& world, EID tid, int x, int y, int current_health, int max_health);
 anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int current_health, int max_health, std::string mesh_name);
 anax::Entity newNonDestroyable(anax::World& world, EID tid, int x, int y, std::string mesh_name);
 

--- a/src/lib-tempo/include/tempo/entity/Health.hpp
+++ b/src/lib-tempo/include/tempo/entity/Health.hpp
@@ -8,10 +8,12 @@ namespace tempo {
 
 	struct ComponentHealth : anax::Component {
 
+	private:
 		//Starting Health for entity
 		int max_health;
 		int current_health;
 
+	public:
 		// ComponentHealth
 		// Initialisation of an entity's Health Component
 		//
@@ -31,6 +33,11 @@ namespace tempo {
 		// Returns:
 		//          void
 		ComponentHealth(int current_health, int max_health);
+
+		int getCurrentHealth();
+		int getMaxHealth();
+
+		void setHealth(int current_health);
 
 		// HealthUpdate
 		// Update the health of an individual entity by a specific amount

--- a/src/lib-tempo/include/tempo/entity/Health.hpp
+++ b/src/lib-tempo/include/tempo/entity/Health.hpp
@@ -21,6 +21,17 @@ namespace tempo {
 		//          void
 		ComponentHealth(int entity_health);
 
+		// ComponentHealth
+		// Initialisation of an entity's Health Component where the starting health is not
+		// the same as the max health
+		//
+		// Arguments:
+		//          current_health - The amount of health to give to the entity
+		//          max_health - the max_health to give to the entity
+		// Returns:
+		//          void
+		ComponentHealth(int current_health, int max_health);
+
 		// HealthUpdate
 		// Update the health of an individual entity by a specific amount
 		//

--- a/src/lib-tempo/include/tempo/entity/Render.hpp
+++ b/src/lib-tempo/include/tempo/entity/Render.hpp
@@ -34,6 +34,15 @@ namespace tempo{
 		// Returns:
 		//          void
 		void AddHealthBar();
+
+		// hasHealthBar
+		// Check whether an entity has a health bar
+		//
+		// Arguments:
+		//          none
+		// Returns:
+		//          bool
+		bool hasHealthBar();
 	};
 
 	/////////////////////////////////////////////////////////////////////

--- a/src/lib-tempo/include/tempo/entity/RenderHealth.hpp
+++ b/src/lib-tempo/include/tempo/entity/RenderHealth.hpp
@@ -6,6 +6,9 @@
 
 #include <tempo/entity/Health.hpp>
 #include <tempo/entity/Render.hpp>
+#include <tempo/entity/GridAi.hpp>
+#include <tempo/entity/PlayerRemote.hpp>
+#include <tempo/entity/PlayerRemoteServer.hpp>
 
 #include <Ogre.h>
 

--- a/src/lib-tempo/src/entity/EntityCreation.cpp
+++ b/src/lib-tempo/src/entity/EntityCreation.cpp
@@ -12,19 +12,15 @@ namespace tempo
 /* 	switch (entity->type_id){ */
 /* 		case EID_PLAYER: */
 /* 			entity->entity_type.player.some_data_for_player = EID_PLAYER; */
-/* 			printf("\n\n\n\n%d\n\n\n\n\n", entity->entity_type.player.some_data_for_player); */
 /* 			break; */
 /* 		case EID_AI: */
 /* 			entity->entity_type.ai.some_data_for_ai = EID_AI; */
-/* 			printf("\n\n\n\n%d\n\n\n\n\n", entity->entity_type.ai.some_data_for_ai); */
 /* 			break; */
 /* 		case EID_DES: */
 /* 			entity->entity_type.destroyable.some_data_for_destroyable = EID_DES; */
-/* 			printf("\n\n\n\n%d\n\n\n\n\n", entity->entity_type.destroyable.some_data_for_destroyable); */
 /* 			break; */
 /* 		case EID_NONDES: */
 /* 			entity->entity_type.nondestroyable.some_data_for_nondestroyable = EID_NONDES; */
-/* 			printf("\n\n\n\n%d\n\n\n\n\n", entity->entity_type.nondestroyable.some_data_for_nondestroyable); */
 /* 			break; */
 /* 		default: printf("Missed all\n"); */
 /* 	} */

--- a/src/lib-tempo/src/entity/EntityCreationClient.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationClient.cpp
@@ -44,11 +44,13 @@ anax::Entity newEntity(EntityCreationData data,
 		case EID_DES:
 			{
 			Destroyable_t d = data.entity_type.destroyable;
-			// int health = data.entity_type.player.health;
+			int current_health = d.current_health;
+			int max_health = d.max_health;
 			return_entity = newDestroyable(world, scene, instance_id, type_id,
 			                               pos.x,
 										   					 		 pos.y,
-										   							 // health,
+										   							 current_health,
+																		 max_health,
 										   							 /* std::string(d.mesh_name) */ // TODO FIX
 									       						 "Cube"
 			                              	);
@@ -122,9 +124,8 @@ anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID t
 	return entity_ai;
 }
 
-anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name) {
+anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health, std::string mesh_name) {
 
-	//TODO:: Add HealthComponent
 	//TODO:: Add Entity to Specific Tile
 
 	anax::Entity entity_object = world.createEntity();
@@ -133,10 +134,9 @@ anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int i
 
 	entity_object.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_object.addComponent<tempo::ComponentTransform>();
-	//entity_object.addComponent<tempo::ComponentHealth>(health);
-	//printf("\n\n ClientDest currently has health = %d\n\n", entity_object.getComponent<tempo::ComponentHealth>().current_health);
+	entity_object.addComponent<tempo::ComponentHealth>(current_health, max_health);
 	entity_object.addComponent<tempo::ComponentRender>(scene, mesh_name).node->attachObject(entity_mesh);
-	//entity_object.addComponent<tempo::ComponentRender>().AddHealthBar();
+	entity_object.getComponent<tempo::ComponentRender>().AddHealthBar();
 	entity_object.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_object.addComponent<tempo::ComponentGridMotion>();
 

--- a/src/lib-tempo/src/entity/EntityCreationClient.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationClient.cpp
@@ -17,9 +17,11 @@ anax::Entity newEntity(EntityCreationData data,
 		case EID_PLAYER:
 			{
 			Player_t p = data.entity_type.player;
+			int health = data.entity_type.player.health;
 			return_entity = newPlayer(world, scene, instance_id, type_id,
 			                          pos.x,
 			                          pos.y,
+									  health,
 			                          system_gm
 			                         );
 			break;
@@ -27,20 +29,24 @@ anax::Entity newEntity(EntityCreationData data,
 		case EID_AI:
 			{
 			AI_t a = data.entity_type.ai;
+			int health = data.entity_type.player.health;
 			return_entity = newAI(world, scene, instance_id, type_id,
 			                      pos.x,
-			                      pos.y
+			                      pos.y,
+								  health
 			                     );
 			break;
 			}
 		case EID_DES:
 			{
 			Destroyable_t d = data.entity_type.destroyable;
+			int health = data.entity_type.player.health;
 			return_entity = newDestroyable(world, scene, instance_id, type_id,
 			                               pos.x,
-					               pos.y,
-					               /* std::string(d.mesh_name) */ // TODO FIX
-					               "Cube"
+										   pos.y,
+										   health,
+										   /* std::string(d.mesh_name) */ // TODO FIX
+									       "Cube"
 			                              );
 			break;
 			}
@@ -60,7 +66,7 @@ anax::Entity newEntity(EntityCreationData data,
 	return return_entity;
 }
 
-anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, tempo::SystemLevelManager system_grid_motion) {
+anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health, tempo::SystemLevelManager system_grid_motion) {
 
 	//TODO:: Add Entity to Specific Tile
 
@@ -76,7 +82,9 @@ anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, E
 	entity_player.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_player.addComponent<tempo::ComponentTransform>();
 	entity_player.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Pset);
+	entity_player.addComponent<tempo::ComponentRender>(scene, "N/A").AddHealthBar();
 	entity_player.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
+	entity_player.addComponent<tempo::ComponentHealth>(health);
 	entity_player.addComponent<tempo::ComponentGridMotion>();
 	entity_player.addComponent<tempo::ComponentPlayerRemote>();
 	entity_player.activate();
@@ -84,7 +92,7 @@ anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, E
 	return entity_player;
 }
 
-anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y) {
+anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health) {
 
 	//TODO:: Add Entity to Specific Tile
 
@@ -97,10 +105,15 @@ anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID t
 	Ogre::Billboard* ai = Aset->createBillboard(0, 0.75, 0);
 	ai->setColour(Ogre::ColourValue::Blue);
 
+	printf("\n\nCreating a new Client AI with Health = %d\n\n", health);
+
 	entity_ai.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_ai.addComponent<tempo::ComponentTransform>();
 	entity_ai.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Aset);
+	entity_ai.addComponent<tempo::ComponentRender>(scene, "N/A").AddHealthBar();
 	entity_ai.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
+	entity_ai.addComponent<tempo::ComponentHealth>(health);
+	printf("\n\n ClientAI currently has health = %d\n\n", entity_ai.getComponent<tempo::ComponentHealth>().current_health);
 	entity_ai.addComponent<tempo::ComponentGridMotion>();
 	entity_ai.addComponent<tempo::ComponentGridAi>();
 	entity_ai.activate();
@@ -108,7 +121,7 @@ anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID t
 	return entity_ai;
 }
 
-anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name) {
+anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health, std::string mesh_name) {
 
 	//TODO:: Add HealthComponent
 	//TODO:: Add Entity to Specific Tile
@@ -120,7 +133,9 @@ anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int i
 	entity_object.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_object.addComponent<tempo::ComponentTransform>();
 	entity_object.addComponent<tempo::ComponentRender>(scene, mesh_name).node->attachObject(entity_mesh);
+	entity_object.addComponent<tempo::ComponentRender>(scene, mesh_name).AddHealthBar();
 	entity_object.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
+	entity_object.addComponent<tempo::ComponentHealth>(health);
 	entity_object.addComponent<tempo::ComponentGridMotion>();
 
 	//TEMP:: Mesh used was too big

--- a/src/lib-tempo/src/entity/EntityCreationClient.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationClient.cpp
@@ -18,6 +18,7 @@ anax::Entity newEntity(EntityCreationData data,
 			{
 			Player_t p = data.entity_type.player;
 			int health = data.entity_type.player.health;
+			printf("\n\n Player new health: %d", health);
 			return_entity = newPlayer(world, scene, instance_id, type_id,
 			                          pos.x,
 			                          pos.y,
@@ -30,6 +31,7 @@ anax::Entity newEntity(EntityCreationData data,
 			{
 			AI_t a = data.entity_type.ai;
 			int health = data.entity_type.player.health;
+			printf("\n\n AI new health: %d", health);
 			return_entity = newAI(world, scene, instance_id, type_id,
 			                      pos.x,
 			                      pos.y,
@@ -81,10 +83,11 @@ anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, E
 	
 	entity_player.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_player.addComponent<tempo::ComponentTransform>();
-	entity_player.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Pset);
-	entity_player.addComponent<tempo::ComponentRender>(scene, "N/A").AddHealthBar();
-	entity_player.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_player.addComponent<tempo::ComponentHealth>(health);
+	printf("\n\n ClientPlayer currently has health = %d\n\n", entity_player.getComponent<tempo::ComponentHealth>().current_health);
+	entity_player.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Pset);
+	entity_player.getComponent<tempo::ComponentRender>().AddHealthBar();
+	entity_player.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_player.addComponent<tempo::ComponentGridMotion>();
 	entity_player.addComponent<tempo::ComponentPlayerRemote>();
 	entity_player.activate();
@@ -105,15 +108,12 @@ anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID t
 	Ogre::Billboard* ai = Aset->createBillboard(0, 0.75, 0);
 	ai->setColour(Ogre::ColourValue::Blue);
 
-	printf("\n\nCreating a new Client AI with Health = %d\n\n", health);
-
 	entity_ai.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_ai.addComponent<tempo::ComponentTransform>();
-	entity_ai.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Aset);
-	entity_ai.addComponent<tempo::ComponentRender>(scene, "N/A").AddHealthBar();
-	entity_ai.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_ai.addComponent<tempo::ComponentHealth>(health);
-	printf("\n\n ClientAI currently has health = %d\n\n", entity_ai.getComponent<tempo::ComponentHealth>().current_health);
+	entity_ai.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Aset);
+	entity_ai.getComponent<tempo::ComponentRender>().AddHealthBar();
+	entity_ai.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_ai.addComponent<tempo::ComponentGridMotion>();
 	entity_ai.addComponent<tempo::ComponentGridAi>();
 	entity_ai.activate();
@@ -132,10 +132,11 @@ anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int i
 
 	entity_object.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_object.addComponent<tempo::ComponentTransform>();
+	//entity_object.addComponent<tempo::ComponentHealth>(health);
+	//printf("\n\n ClientDest currently has health = %d\n\n", entity_object.getComponent<tempo::ComponentHealth>().current_health);
 	entity_object.addComponent<tempo::ComponentRender>(scene, mesh_name).node->attachObject(entity_mesh);
-	entity_object.addComponent<tempo::ComponentRender>(scene, mesh_name).AddHealthBar();
+	//entity_object.addComponent<tempo::ComponentRender>().AddHealthBar();
 	entity_object.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
-	entity_object.addComponent<tempo::ComponentHealth>(health);
 	entity_object.addComponent<tempo::ComponentGridMotion>();
 
 	//TEMP:: Mesh used was too big

--- a/src/lib-tempo/src/entity/EntityCreationClient.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationClient.cpp
@@ -2,7 +2,7 @@
 
 namespace tempo {
 
-anax::Entity newEntity(EntityCreationData data, 
+anax::Entity newEntity(EntityCreationData data,
                        anax::World& world,
                        Ogre::SceneManager* scene,
                        tempo::SystemLevelManager system_gm)
@@ -17,12 +17,13 @@ anax::Entity newEntity(EntityCreationData data,
 		case EID_PLAYER:
 			{
 			Player_t p = data.entity_type.player;
-			int health = data.entity_type.player.health;
-			printf("\n\n Player new health: %d", health);
+			int current_health = data.entity_type.player.current_health;
+			int max_health = data.entity_type.player.max_health;
 			return_entity = newPlayer(world, scene, instance_id, type_id,
 			                          pos.x,
 			                          pos.y,
-									  health,
+									  					  current_health,
+																max_health,
 			                          system_gm
 			                         );
 			break;
@@ -30,26 +31,27 @@ anax::Entity newEntity(EntityCreationData data,
 		case EID_AI:
 			{
 			AI_t a = data.entity_type.ai;
-			int health = data.entity_type.player.health;
-			printf("\n\n AI new health: %d", health);
+			int current_health = data.entity_type.ai.current_health;
+			int max_health = data.entity_type.ai.max_health;
 			return_entity = newAI(world, scene, instance_id, type_id,
 			                      pos.x,
 			                      pos.y,
-								  health
+														current_health,
+														max_health
 			                     );
 			break;
 			}
 		case EID_DES:
 			{
 			Destroyable_t d = data.entity_type.destroyable;
-			int health = data.entity_type.player.health;
+			// int health = data.entity_type.player.health;
 			return_entity = newDestroyable(world, scene, instance_id, type_id,
 			                               pos.x,
-										   pos.y,
-										   health,
-										   /* std::string(d.mesh_name) */ // TODO FIX
-									       "Cube"
-			                              );
+										   					 		 pos.y,
+										   							 // health,
+										   							 /* std::string(d.mesh_name) */ // TODO FIX
+									       						 "Cube"
+			                              	);
 			break;
 			}
 		case EID_NONDES:
@@ -68,7 +70,7 @@ anax::Entity newEntity(EntityCreationData data,
 	return return_entity;
 }
 
-anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health, tempo::SystemLevelManager system_grid_motion) {
+anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health, tempo::SystemLevelManager system_grid_motion) {
 
 	//TODO:: Add Entity to Specific Tile
 
@@ -80,10 +82,10 @@ anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, E
 	Pset->setCommonDirection(Ogre::Vector3(0, 1, 0));
 	Ogre::Billboard* player = Pset->createBillboard(0, 0.75, 0);
 	player->setColour(Ogre::ColourValue::Red);
-	
+
 	entity_player.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_player.addComponent<tempo::ComponentTransform>();
-	entity_player.addComponent<tempo::ComponentHealth>(health);
+	entity_player.addComponent<tempo::ComponentHealth>(current_health,max_health);
 	printf("\n\n ClientPlayer currently has health = %d\n\n", entity_player.getComponent<tempo::ComponentHealth>().current_health);
 	entity_player.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Pset);
 	entity_player.getComponent<tempo::ComponentRender>().AddHealthBar();
@@ -95,7 +97,7 @@ anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, E
 	return entity_player;
 }
 
-anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health) {
+anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int current_health, int max_health) {
 
 	//TODO:: Add Entity to Specific Tile
 
@@ -110,7 +112,7 @@ anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID t
 
 	entity_ai.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_ai.addComponent<tempo::ComponentTransform>();
-	entity_ai.addComponent<tempo::ComponentHealth>(health);
+	entity_ai.addComponent<tempo::ComponentHealth>(current_health,max_health);
 	entity_ai.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Aset);
 	entity_ai.getComponent<tempo::ComponentRender>().AddHealthBar();
 	entity_ai.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
@@ -121,11 +123,11 @@ anax::Entity newAI(anax::World& world, Ogre::SceneManager* scene, int iid, EID t
 	return entity_ai;
 }
 
-anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, int health, std::string mesh_name) {
+anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name) {
 
 	//TODO:: Add HealthComponent
 	//TODO:: Add Entity to Specific Tile
-	
+
 	anax::Entity entity_object = world.createEntity();
 	std::string filename = "meshes/" + mesh_name + ".mesh";
 	Ogre::Entity* entity_mesh = scene->createEntity(filename);

--- a/src/lib-tempo/src/entity/EntityCreationClient.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationClient.cpp
@@ -22,8 +22,8 @@ anax::Entity newEntity(EntityCreationData data,
 			return_entity = newPlayer(world, scene, instance_id, type_id,
 			                          pos.x,
 			                          pos.y,
-									  					  current_health,
-																max_health,
+									  current_health,
+									  max_health,
 			                          system_gm
 			                         );
 			break;
@@ -36,23 +36,23 @@ anax::Entity newEntity(EntityCreationData data,
 			return_entity = newAI(world, scene, instance_id, type_id,
 			                      pos.x,
 			                      pos.y,
-														current_health,
-														max_health
+								  current_health,
+								  max_health
 			                     );
 			break;
 			}
 		case EID_DES:
 			{
 			Destroyable_t d = data.entity_type.destroyable;
-			int current_health = d.current_health;
-			int max_health = d.max_health;
+			int current_health = data.entity_type.destroyable.current_health;
+			int max_health = data.entity_type.destroyable.max_health;
 			return_entity = newDestroyable(world, scene, instance_id, type_id,
 			                               pos.x,
-										   					 		 pos.y,
-										   							 current_health,
-																		 max_health,
-										   							 /* std::string(d.mesh_name) */ // TODO FIX
-									       						 "Cube"
+										   pos.y,
+										   current_health,
+										   max_health,
+										   /* std::string(d.mesh_name) */ // TODO FIX
+									       "Cube"
 			                              	);
 			break;
 			}
@@ -134,11 +134,10 @@ anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int i
 
 	entity_object.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_object.addComponent<tempo::ComponentTransform>();
-	entity_object.addComponent<tempo::ComponentHealth>(current_health, max_health);
-	entity_object.addComponent<tempo::ComponentRender>(scene, mesh_name).node->attachObject(entity_mesh);
-	entity_object.getComponent<tempo::ComponentRender>().AddHealthBar();
 	entity_object.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_object.addComponent<tempo::ComponentGridMotion>();
+	entity_object.addComponent<tempo::ComponentHealth>(current_health, max_health);
+	entity_object.addComponent<tempo::ComponentRender>(scene, mesh_name).node->attachObject(entity_mesh);
 
 	//TEMP:: Mesh used was too big
 	Ogre::SceneNode* node_object = entity_object.getComponent<tempo::ComponentRender>().node;
@@ -151,8 +150,6 @@ anax::Entity newDestroyable(anax::World& world, Ogre::SceneManager* scene, int i
 }
 
 anax::Entity newNonDestroyable(anax::World& world, Ogre::SceneManager* scene, int iid, EID tid, int x, int y, std::string mesh_name) {
-
-	//TODO:: Add Entity to Specific Tile
 
 	anax::Entity entity_object = world.createEntity();
 	std::string filename = "meshes/" + mesh_name + ".mesh";

--- a/src/lib-tempo/src/entity/EntityCreationClient.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationClient.cpp
@@ -86,7 +86,6 @@ anax::Entity newPlayer(anax::World& world, Ogre::SceneManager* scene, int iid, E
 	entity_player.addComponent<tempo::ComponentID>(iid, (int)tid);
 	entity_player.addComponent<tempo::ComponentTransform>();
 	entity_player.addComponent<tempo::ComponentHealth>(current_health,max_health);
-	printf("\n\n ClientPlayer currently has health = %d\n\n", entity_player.getComponent<tempo::ComponentHealth>().current_health);
 	entity_player.addComponent<tempo::ComponentRender>(scene, "N/A").node->attachObject(Pset);
 	entity_player.getComponent<tempo::ComponentRender>().AddHealthBar();
 	entity_player.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);

--- a/src/lib-tempo/src/entity/EntityCreationServer.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationServer.cpp
@@ -18,9 +18,12 @@ EntityCreationData dumpEntity(anax::Entity e)
 			{
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			Player_t p;
+
+			//TODO:: Replace the next line with getcurrent health and get max health and send them to client and update the recieves as if the entity has already lost health the new guys need to know about it
 			p.health = 1000;
 			Entity_Type t;
-			t. player = p;
+			t.player = p;
+			printf("\n\nplayer dump health : %d\n\n", t.player.health);
 			EntityCreationData data = {type_id, position, instance_id, t};
 			return data;
 			break;
@@ -32,6 +35,7 @@ EntityCreationData dumpEntity(anax::Entity e)
 			a.health = 1000;
 			Entity_Type t;
 			t.ai = a;
+			printf("\n\nai dump health : %d\n\n", t.ai.health);
 			EntityCreationData data = {type_id, position, instance_id, t};
 			return data;
 			break;
@@ -82,6 +86,7 @@ anax::Entity newPlayer(anax::World& world, EID tid, tempo::SystemLevelManager sy
 	entity_player.addComponent<tempo::ComponentGridPosition>(system_grid_motion.spawn());
 	entity_player.addComponent<tempo::ComponentGridMotion>();
 	entity_player.addComponent<tempo::ComponentHealth>(1000);
+	printf("\n\n ServerPlayer currently has health = %d\n\n", entity_player.getComponent<tempo::ComponentHealth>().current_health);
 	entity_player.addComponent<tempo::ComponentPlayerRemoteServer>();	
 	
 	entity_player.activate();
@@ -95,15 +100,11 @@ anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health) {
 
 	anax::Entity entity_ai = world.createEntity();
 
-	printf("\n\nCreating a new Server AI with Health = %d\n\n", health);
-
 	entity_ai.addComponent<tempo::ComponentID>((int)tid);
 	entity_ai.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_ai.addComponent<tempo::ComponentGridMotion>();
 	entity_ai.addComponent<tempo::ComponentGridAi>();
 	entity_ai.addComponent<tempo::ComponentHealth>(health);
-
-	printf("\n\n ServerAI currently has health = %d\n\n",entity_ai.getComponent<tempo::ComponentHealth>().current_health);
 	int iid = entity_ai.getComponent<tempo::ComponentID>().instance_id;
 	entity_ai.activate();
 
@@ -120,7 +121,8 @@ anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int healt
 	entity_object.addComponent<tempo::ComponentID>((int)tid);
 	entity_object.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_object.addComponent<tempo::ComponentGridMotion>();
-	entity_object.addComponent<tempo::ComponentHealth>(health);
+	//entity_object.addComponent<tempo::ComponentHealth>(health);
+	//printf("\n\n ServerDest currently has health = %d\n\n", entity_object.getComponent<tempo::ComponentHealth>().current_health);
 
 	entity_object.activate();
 

--- a/src/lib-tempo/src/entity/EntityCreationServer.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationServer.cpp
@@ -45,8 +45,8 @@ EntityCreationData dumpEntity(anax::Entity e)
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			Destroyable_t d;
 			d.current_health = e.getComponent<tempo::ComponentHealth>().getCurrentHealth();
-			memset(&(d.mesh_name), 0, 100);
 			d.current_health = e.getComponent<tempo::ComponentHealth>().getMaxHealth();
+			memset(&(d.mesh_name), 0, 100);
 
 			// TODO Sort this
 			/* memcpy((void*)e.getComponent<ComponentRender>().path.c_str(), &(d.mesh_name), 100); */
@@ -94,9 +94,7 @@ anax::Entity newPlayer(anax::World& world, EID tid, tempo::SystemLevelManager sy
 	return entity_player;
 }
 
-anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health) {
-
-	//TODO:: Add Entity to Specific Tile
+anax::Entity newAI(anax::World& world, EID tid, int x, int y, int current_health, int max_health) {
 
 	anax::Entity entity_ai = world.createEntity();
 
@@ -104,7 +102,7 @@ anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health) {
 	entity_ai.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_ai.addComponent<tempo::ComponentGridMotion>();
 	entity_ai.addComponent<tempo::ComponentGridAi>();
-	entity_ai.addComponent<tempo::ComponentHealth>(health);
+	entity_ai.addComponent<tempo::ComponentHealth>(current_health, max_health);
 	int iid = entity_ai.getComponent<tempo::ComponentID>().instance_id;
 	entity_ai.activate();
 
@@ -113,16 +111,12 @@ anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health) {
 
 anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int current_health, int max_health, std::string mesh_name) {
 
-	//TODO:: Add HealthComponent
-	//TODO:: Add Entity to Specific Tile
-
 	anax::Entity entity_object = world.createEntity();
 
 	entity_object.addComponent<tempo::ComponentID>((int)tid);
 	entity_object.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_object.addComponent<tempo::ComponentGridMotion>();
 	entity_object.addComponent<tempo::ComponentHealth>(current_health, max_health);
-	//printf("\n\n ServerDest currently has health = %d\n\n", entity_object.getComponent<tempo::ComponentHealth>().current_health);
 
 	entity_object.activate();
 
@@ -131,8 +125,6 @@ anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int curre
 }
 
 anax::Entity newNonDestroyable(anax::World& world, EID tid, int x, int y, std::string mesh_name) {
-
-	//TODO:: Add Entity to Specific Tile
 
 	anax::Entity entity_object = world.createEntity();
 

--- a/src/lib-tempo/src/entity/EntityCreationServer.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationServer.cpp
@@ -20,8 +20,8 @@ EntityCreationData dumpEntity(anax::Entity e)
 			Player_t p;
 
 			//TODO:: Replace the next line with getcurrent health and get max health and send them to client and update the recieves as if the entity has already lost health the new guys need to know about it
-			p.current_health = e.getComponent<tempo::ComponentHealth>().current_health;
-			p.max_health = e.getComponent<tempo::ComponentHealth>().max_health;
+			p.current_health = e.getComponent<tempo::ComponentHealth>().getCurrentHealth();
+			p.max_health = e.getComponent<tempo::ComponentHealth>().getCurrentHealth();
 			Entity_Type t;
 			t.player = p;
 			EntityCreationData data = {type_id, position, instance_id, t};
@@ -32,8 +32,8 @@ EntityCreationData dumpEntity(anax::Entity e)
 			{
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			AI_t a;
-			a.current_health = e.getComponent<tempo::ComponentHealth>().current_health;
-			a.max_health = e.getComponent<tempo::ComponentHealth>().max_health;
+			a.current_health = e.getComponent<tempo::ComponentHealth>().getCurrentHealth();
+			a.max_health = e.getComponent<tempo::ComponentHealth>().getMaxHealth();
 			Entity_Type t;
 			t.ai = a;
 			EntityCreationData data = {type_id, position, instance_id, t};
@@ -86,7 +86,6 @@ anax::Entity newPlayer(anax::World& world, EID tid, tempo::SystemLevelManager sy
 	entity_player.addComponent<tempo::ComponentGridPosition>(system_grid_motion.spawn());
 	entity_player.addComponent<tempo::ComponentGridMotion>();
 	entity_player.addComponent<tempo::ComponentHealth>(1000);
-	printf("\n\n ServerPlayer currently has health = %d\n\n", entity_player.getComponent<tempo::ComponentHealth>().current_health);
 	entity_player.addComponent<tempo::ComponentPlayerRemoteServer>();
 
 	entity_player.activate();

--- a/src/lib-tempo/src/entity/EntityCreationServer.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationServer.cpp
@@ -18,7 +18,7 @@ EntityCreationData dumpEntity(anax::Entity e)
 			{
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			Player_t p;
-			p.foo = 0;
+			p.health = 1000;
 			Entity_Type t;
 			t. player = p;
 			EntityCreationData data = {type_id, position, instance_id, t};
@@ -29,7 +29,7 @@ EntityCreationData dumpEntity(anax::Entity e)
 			{
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			AI_t a;
-			a.foo = 0;
+			a.health = 1000;
 			Entity_Type t;
 			t.ai = a;
 			EntityCreationData data = {type_id, position, instance_id, t};
@@ -40,6 +40,7 @@ EntityCreationData dumpEntity(anax::Entity e)
 			{
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			Destroyable_t d;
+			d.health = 100;
 			memset(&(d.mesh_name), 0, 100);
 			
 			// TODO Sort this
@@ -80,6 +81,7 @@ anax::Entity newPlayer(anax::World& world, EID tid, tempo::SystemLevelManager sy
 	int iid = entity_player.getComponent<tempo::ComponentID>().instance_id;
 	entity_player.addComponent<tempo::ComponentGridPosition>(system_grid_motion.spawn());
 	entity_player.addComponent<tempo::ComponentGridMotion>();
+	entity_player.addComponent<tempo::ComponentHealth>(1000);
 	entity_player.addComponent<tempo::ComponentPlayerRemoteServer>();	
 	
 	entity_player.activate();
@@ -87,23 +89,28 @@ anax::Entity newPlayer(anax::World& world, EID tid, tempo::SystemLevelManager sy
 	return entity_player;
 }
 
-anax::Entity newAI(anax::World& world, EID tid, int x, int y) {
+anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health) {
 
 	//TODO:: Add Entity to Specific Tile
 
 	anax::Entity entity_ai = world.createEntity();
 
+	printf("\n\nCreating a new Server AI with Health = %d\n\n", health);
+
 	entity_ai.addComponent<tempo::ComponentID>((int)tid);
 	entity_ai.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_ai.addComponent<tempo::ComponentGridMotion>();
 	entity_ai.addComponent<tempo::ComponentGridAi>();
+	entity_ai.addComponent<tempo::ComponentHealth>(health);
+
+	printf("\n\n ServerAI currently has health = %d\n\n",entity_ai.getComponent<tempo::ComponentHealth>().current_health);
 	int iid = entity_ai.getComponent<tempo::ComponentID>().instance_id;
 	entity_ai.activate();
 
 	return entity_ai;
 }
 
-anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, std::string mesh_name) {
+anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int health, std::string mesh_name) {
 
 	//TODO:: Add HealthComponent
 	//TODO:: Add Entity to Specific Tile
@@ -113,6 +120,7 @@ anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, std::stri
 	entity_object.addComponent<tempo::ComponentID>((int)tid);
 	entity_object.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_object.addComponent<tempo::ComponentGridMotion>();
+	entity_object.addComponent<tempo::ComponentHealth>(health);
 
 	entity_object.activate();
 

--- a/src/lib-tempo/src/entity/EntityCreationServer.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationServer.cpp
@@ -44,8 +44,9 @@ EntityCreationData dumpEntity(anax::Entity e)
 			{
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			Destroyable_t d;
-			// d.health = 100;
+			d.current_health = e.getComponent<tempo::ComponentHealth>().getCurrentHealth();
 			memset(&(d.mesh_name), 0, 100);
+			d.current_health = e.getComponent<tempo::ComponentHealth>().getMaxHealth();
 
 			// TODO Sort this
 			/* memcpy((void*)e.getComponent<ComponentRender>().path.c_str(), &(d.mesh_name), 100); */
@@ -110,7 +111,7 @@ anax::Entity newAI(anax::World& world, EID tid, int x, int y, int health) {
 	return entity_ai;
 }
 
-anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int health, std::string mesh_name) {
+anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int current_health, int max_health, std::string mesh_name) {
 
 	//TODO:: Add HealthComponent
 	//TODO:: Add Entity to Specific Tile
@@ -120,7 +121,7 @@ anax::Entity newDestroyable(anax::World& world, EID tid, int x, int y, int healt
 	entity_object.addComponent<tempo::ComponentID>((int)tid);
 	entity_object.addComponent<tempo::ComponentGridPosition>(x, y, tempo::tileMask1by1, false);
 	entity_object.addComponent<tempo::ComponentGridMotion>();
-	//entity_object.addComponent<tempo::ComponentHealth>(health);
+	entity_object.addComponent<tempo::ComponentHealth>(current_health, max_health);
 	//printf("\n\n ServerDest currently has health = %d\n\n", entity_object.getComponent<tempo::ComponentHealth>().current_health);
 
 	entity_object.activate();

--- a/src/lib-tempo/src/entity/EntityCreationServer.cpp
+++ b/src/lib-tempo/src/entity/EntityCreationServer.cpp
@@ -20,10 +20,10 @@ EntityCreationData dumpEntity(anax::Entity e)
 			Player_t p;
 
 			//TODO:: Replace the next line with getcurrent health and get max health and send them to client and update the recieves as if the entity has already lost health the new guys need to know about it
-			p.health = 1000;
+			p.current_health = e.getComponent<tempo::ComponentHealth>().current_health;
+			p.max_health = e.getComponent<tempo::ComponentHealth>().max_health;
 			Entity_Type t;
 			t.player = p;
-			printf("\n\nplayer dump health : %d\n\n", t.player.health);
 			EntityCreationData data = {type_id, position, instance_id, t};
 			return data;
 			break;
@@ -32,10 +32,10 @@ EntityCreationData dumpEntity(anax::Entity e)
 			{
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			AI_t a;
-			a.health = 1000;
+			a.current_health = e.getComponent<tempo::ComponentHealth>().current_health;
+			a.max_health = e.getComponent<tempo::ComponentHealth>().max_health;
 			Entity_Type t;
 			t.ai = a;
-			printf("\n\nai dump health : %d\n\n", t.ai.health);
 			EntityCreationData data = {type_id, position, instance_id, t};
 			return data;
 			break;
@@ -44,9 +44,9 @@ EntityCreationData dumpEntity(anax::Entity e)
 			{
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			Destroyable_t d;
-			d.health = 100;
+			// d.health = 100;
 			memset(&(d.mesh_name), 0, 100);
-			
+
 			// TODO Sort this
 			/* memcpy((void*)e.getComponent<ComponentRender>().path.c_str(), &(d.mesh_name), 100); */
 
@@ -61,10 +61,10 @@ EntityCreationData dumpEntity(anax::Entity e)
 			position = e.getComponent<ComponentGridPosition>().getPosition();
 			NonDestroyable_t n;
 			memset(&(n.mesh_name), 0, 100);
-			
+
 			// TODO Sort this
 			/* memcpy((void*)e.getComponent<ComponentRender>().path.c_str(), &(n.mesh_name), 100); */
-			
+
 			Entity_Type t;
 			t.nondestroyable = n;
 			EntityCreationData data = {type_id, position, instance_id, t};
@@ -80,15 +80,15 @@ anax::Entity newPlayer(anax::World& world, EID tid, tempo::SystemLevelManager sy
 	//TODO:: Add Entity to Specific Tile
 
 	anax::Entity entity_player = world.createEntity();
-	
+
 	entity_player.addComponent<tempo::ComponentID>((int)tid);
 	int iid = entity_player.getComponent<tempo::ComponentID>().instance_id;
 	entity_player.addComponent<tempo::ComponentGridPosition>(system_grid_motion.spawn());
 	entity_player.addComponent<tempo::ComponentGridMotion>();
 	entity_player.addComponent<tempo::ComponentHealth>(1000);
 	printf("\n\n ServerPlayer currently has health = %d\n\n", entity_player.getComponent<tempo::ComponentHealth>().current_health);
-	entity_player.addComponent<tempo::ComponentPlayerRemoteServer>();	
-	
+	entity_player.addComponent<tempo::ComponentPlayerRemoteServer>();
+
 	entity_player.activate();
 
 	return entity_player;

--- a/src/lib-tempo/src/entity/Health.cpp
+++ b/src/lib-tempo/src/entity/Health.cpp
@@ -56,19 +56,6 @@ namespace tempo {
 
 	}
 
-	void SystemHealth::HealthUpdate(int delta_health) {
-
-		auto entities = getEntities();
-
-		for (auto& entity : entities) {
-			auto& h = entity.getComponent<ComponentHealth>();
-			int id = entity.getId();
-
-			h.HealthUpdate(delta_health);
-
-		}
-	}
-
 	void SystemHealth::CheckHealth() {
 
 		auto entities = getEntities();

--- a/src/lib-tempo/src/entity/Health.cpp
+++ b/src/lib-tempo/src/entity/Health.cpp
@@ -9,6 +9,14 @@ namespace tempo {
 		this->current_health = entity_health;
 	}
 
+	ComponentHealth::ComponentHealth(int current_health, int max_health) {
+
+		//Assign Health to Entity
+		this->max_health = max_health;
+		this->current_health = current_health;
+
+	}
+
 	void ComponentHealth::HealthUpdate(int delta_health){
 
 		// The entity's current health should not exceed the maximum health of the entity

--- a/src/lib-tempo/src/entity/Health.cpp
+++ b/src/lib-tempo/src/entity/Health.cpp
@@ -17,6 +17,26 @@ namespace tempo {
 
 	}
 
+	int ComponentHealth::getCurrentHealth(){
+		return (this->current_health);
+	}
+
+	int ComponentHealth::getMaxHealth(){
+		return this->max_health;
+	}
+
+	void ComponentHealth::setHealth(int current_health){
+
+					if(current_health <= (this->current_health)){
+						this->current_health = current_health;
+					}
+
+					else{
+						this->current_health = this->max_health;
+					}
+
+	}
+
 	void ComponentHealth::HealthUpdate(int delta_health){
 
 		// The entity's current health should not exceed the maximum health of the entity
@@ -44,20 +64,8 @@ namespace tempo {
 			auto& h = entity.getComponent<ComponentHealth>();
 			int id = entity.getId();
 
-			// The entity's current health should not exceed the maximum health of the entity
-			if ((h.current_health) + delta_health > (h.max_health)) {
-				h.current_health = h.max_health;
-			}
+			h.HealthUpdate(delta_health);
 
-			// Apply change to current health
-			else {
-				h.current_health += delta_health;
-			}
-
-			// Stop health from going less than 0
-			if ((h.current_health < 0)) {
-				h.current_health = 0;
-			}
 		}
 	}
 
@@ -70,7 +78,7 @@ namespace tempo {
 			int id = entity.getId();
 
 			// If the entity has 0 health then kill entity
-			if ((h.current_health <= 0)){
+			if ((h.getCurrentHealth() <= 0)){
 				printf("\nEntity ID: %d has just been \"killed\". \n", id);
 				// TODO: Sort something out for here
 				// entity.kill();

--- a/src/lib-tempo/src/entity/Render.cpp
+++ b/src/lib-tempo/src/entity/Render.cpp
@@ -5,6 +5,10 @@ namespace tempo{
 		this->path = path;
 		this->scene = scene;
 		this->node  = scene->getRootSceneNode()->createChildSceneNode();
+
+		//incase the entity hasnt got a healthbar (i.e destroyables)
+		this->healthBarnode = NULL;
+		this->healthBillboard = NULL;
 	}
 
 
@@ -30,6 +34,13 @@ namespace tempo{
 		this->healthBarnode = this->node->createChildSceneNode();
 
 		this->healthBarnode->attachObject(Healthset);
+	}
+
+	bool ComponentRender::hasHealthBar() {
+		if (this->healthBarnode == NULL) {
+			return false;
+		}
+		else return true;
 	}
 
 	SystemRender::SystemRender(Application& new_app) : app(new_app) {

--- a/src/lib-tempo/src/entity/RenderHealth.cpp
+++ b/src/lib-tempo/src/entity/RenderHealth.cpp
@@ -10,19 +10,29 @@ namespace tempo {
 			auto& h = entity.getComponent<ComponentHealth>();
 			auto& rend  = entity.getComponent<ComponentRender>();
 
+			printf("\n\n RenderHealth 12\n\n");
 			// Fraction of health left
 			scale = (double) h.current_health / h.max_health;
-
+			printf("\n\n RenderHealth 15\n\n");
 			// Set scale of healthbar based on current health value
-			rend.healthBarnode->setScale(scale,1,1);
-
+			printf("\nScale %f\n", scale);
+			printf("\current health %d\n", h.current_health);
+			printf("\nmax health %d\n", h.max_health);
+			if (h.max_health != 0) {
+				rend.healthBarnode->setScale(scale, 1, 1);
+			}
+			printf("\n\n RenderHealth 18\n\n");
 			// Set colour of healthbar (Green = full health, Red = No Health)
 			if(scale <= 0.5){
+				printf("\n\n RenderHealth 21\n\n");
 				rend.healthBillboard->setColour(Ogre::ColourValue(1,(scale/0.5),0));
+				printf("\n\n RenderHealth 23\n\n");
 			}
 
 			else{
+				printf("\n\n RenderHealth 27\n\n");
 				rend.healthBillboard->setColour(Ogre::ColourValue(((1-scale)/0.5),1,0));
+				printf("\n\n RenderHealth 29\n\n");
 			}
 
 		}

--- a/src/lib-tempo/src/entity/RenderHealth.cpp
+++ b/src/lib-tempo/src/entity/RenderHealth.cpp
@@ -9,6 +9,9 @@ namespace tempo {
 		for(auto& entity : entities){
 			auto& h = entity.getComponent<ComponentHealth>();
 			auto& rend  = entity.getComponent<ComponentRender>();
+			bool ai = entity.hasComponent<ComponentGridAi>();
+			bool player1 = entity.hasComponent<ComponentPlayerRemote>();
+			bool player2 = entity.hasComponent<ComponentPlayerRemoteServer>();
 
 			printf("\n\n RenderHealth 12\n\n");
 			// Fraction of health left
@@ -18,9 +21,16 @@ namespace tempo {
 			printf("\nScale %f\n", scale);
 			printf("\current health %d\n", h.current_health);
 			printf("\nmax health %d\n", h.max_health);
-			if (h.max_health != 0) {
-				rend.healthBarnode->setScale(scale, 1, 1);
+			if (ai) {
+				printf("\n\n AI \n\n");
 			}
+			else if (player1 || player2) {
+				printf("\n\n Player \n\n");
+			}
+			else {
+				printf("\n\nDest\n\n");
+			}
+			rend.healthBarnode->setScale(scale, 1, 1);
 			printf("\n\n RenderHealth 18\n\n");
 			// Set colour of healthbar (Green = full health, Red = No Health)
 			if(scale <= 0.5){

--- a/src/lib-tempo/src/entity/RenderHealth.cpp
+++ b/src/lib-tempo/src/entity/RenderHealth.cpp
@@ -6,23 +6,26 @@ namespace tempo {
 		auto entities = getEntities();
 		double scale;
 
-		for(auto& entity : entities){
+		for (auto& entity : entities) {
 			auto& h = entity.getComponent<ComponentHealth>();
-			auto& rend  = entity.getComponent<ComponentRender>();
+			auto& rend = entity.getComponent<ComponentRender>();
+			bool hasHealthBar = rend.hasHealthBar();
 
-			// Fraction of health left
-			scale = (double) h.getCurrentHealth() / h.getMaxHealth();
-			// Set scale of healthbar based on current health value
-			rend.healthBarnode->setScale(scale, 1, 1);
-			// Set colour of healthbar (Green = full health, Red = No Health)
-			if(scale <= 0.5){
-				rend.healthBillboard->setColour(Ogre::ColourValue(1,(scale/0.5),0));
+			if (hasHealthBar) {
+				// Fraction of health left
+				scale = (double)h.getCurrentHealth() / h.getMaxHealth();
+				// Set scale of healthbar based on current health value
+				rend.healthBarnode->setScale(scale, 1, 1);
+				// Set colour of healthbar (Green = full health, Red = No Health)
+				if (scale <= 0.5) {
+					rend.healthBillboard->setColour(Ogre::ColourValue(1, (scale / 0.5), 0));
+				}
+
+				else {
+					rend.healthBillboard->setColour(Ogre::ColourValue(((1 - scale) / 0.5), 1, 0));
+				}
+
 			}
-
-			else{
-				rend.healthBillboard->setColour(Ogre::ColourValue(((1-scale)/0.5),1,0));
-			}
-
 		}
 	}
 }

--- a/src/lib-tempo/src/entity/RenderHealth.cpp
+++ b/src/lib-tempo/src/entity/RenderHealth.cpp
@@ -9,40 +9,18 @@ namespace tempo {
 		for(auto& entity : entities){
 			auto& h = entity.getComponent<ComponentHealth>();
 			auto& rend  = entity.getComponent<ComponentRender>();
-			bool ai = entity.hasComponent<ComponentGridAi>();
-			bool player1 = entity.hasComponent<ComponentPlayerRemote>();
-			bool player2 = entity.hasComponent<ComponentPlayerRemoteServer>();
 
-			printf("\n\n RenderHealth 12\n\n");
 			// Fraction of health left
-			scale = (double) h.current_health / h.max_health;
-			printf("\n\n RenderHealth 15\n\n");
+			scale = (double) h.getCurrentHealth() / h.getMaxHealth();
 			// Set scale of healthbar based on current health value
-			printf("\nScale %f\n", scale);
-			printf("\current health %d\n", h.current_health);
-			printf("\nmax health %d\n", h.max_health);
-			if (ai) {
-				printf("\n\n AI \n\n");
-			}
-			else if (player1 || player2) {
-				printf("\n\n Player \n\n");
-			}
-			else {
-				printf("\n\nDest\n\n");
-			}
 			rend.healthBarnode->setScale(scale, 1, 1);
-			printf("\n\n RenderHealth 18\n\n");
 			// Set colour of healthbar (Green = full health, Red = No Health)
 			if(scale <= 0.5){
-				printf("\n\n RenderHealth 21\n\n");
 				rend.healthBillboard->setColour(Ogre::ColourValue(1,(scale/0.5),0));
-				printf("\n\n RenderHealth 23\n\n");
 			}
 
 			else{
-				printf("\n\n RenderHealth 27\n\n");
 				rend.healthBillboard->setColour(Ogre::ColourValue(((1-scale)/0.5),1,0));
-				printf("\n\n RenderHealth 29\n\n");
 			}
 
 		}

--- a/src/lib-tempo/src/network/client.cpp
+++ b/src/lib-tempo/src/network/client.cpp
@@ -123,6 +123,8 @@ uint32_t handshakeHello(anax::World& world,
 		EntityCreationData e;
 		for (int i = 0; i < entityCount; i++) {
 			packet >> e;
+			//TODO:: Recieves 0!!!!!!!!!!!!!!!!!
+			printf("\n\n Client Receives health: %d", e.entity_type.player.health);
 			newEntity(e, world, scene, system_gm);
 		}
 	} else {

--- a/src/lib-tempo/src/network/client.cpp
+++ b/src/lib-tempo/src/network/client.cpp
@@ -34,7 +34,7 @@ sf::Time timeSyncClient(tempo::Clock *clock)
 		return sf::Time::Zero;
 	}
 
-	// End time sync exchange, calculate delay in last tranmission from 
+	// End time sync exchange, calculate delay in last tranmission from
 	// time sync server.
 	t3 = clock->get_time().asMicroseconds();
 	packet >> t1 >> t2;
@@ -44,9 +44,9 @@ sf::Time timeSyncClient(tempo::Clock *clock)
 	return sf::microseconds(t2 + delay);
 }
 
-bool sendMessage(tempo::SystemQID id, 
-                 sf::Packet payload, 
-                 bool isHandshake = false) 
+bool sendMessage(tempo::SystemQID id,
+                 sf::Packet payload,
+                 bool isHandshake = false)
 {
 	sf::Packet message;
 
@@ -54,7 +54,7 @@ bool sendMessage(tempo::SystemQID id,
 	message << id;
 	message << payload;
 
-	
+
 
 	// Send message
 	if (isHandshake) {
@@ -93,7 +93,7 @@ void listenForServerUpdates()
 	return;
 }
 
-uint32_t handshakeHello(anax::World& world, 
+uint32_t handshakeHello(anax::World& world,
 		        Ogre::SceneManager *scene,
                         tempo::SystemLevelManager system_gm)
 {
@@ -123,8 +123,6 @@ uint32_t handshakeHello(anax::World& world,
 		EntityCreationData e;
 		for (int i = 0; i < entityCount; i++) {
 			packet >> e;
-			//TODO:: Recieves 0!!!!!!!!!!!!!!!!!
-			printf("\n\n Client Receives health: %d", e.entity_type.player.health);
 			newEntity(e, world, scene, system_gm);
 		}
 	} else {
@@ -135,11 +133,11 @@ uint32_t handshakeHello(anax::World& world,
 	return id;
 }
 
-bool handshakeRoleReq(uint32_t id, 
-                      ClientRole roleID, 
+bool handshakeRoleReq(uint32_t id,
+                      ClientRole roleID,
                       ClientRoleData &roleData,
                       anax::World& world,
-		      Ogre::SceneManager *scene,
+		      						Ogre::SceneManager *scene,
                       tempo::SystemLevelManager system_gm)
 {
 	// Package up payload
@@ -148,15 +146,15 @@ bool handshakeRoleReq(uint32_t id,
 	packet << id;
 	packet << roleID;
 	packet << roleData;
-	
+
 	// Send ROLEREQ
 	sock_o.send(packet, addr_r, port_sh);
-	
+
 	// Receive ROLEREQ_ROG
 	sf::IpAddress sender;
 	unsigned short port;
 	sock_o.receive(packet, sender, port);
-	
+
 	// Extract Data
 	uint32_t msg = static_cast<uint32_t>(HandshakeID::DEFAULT);
 	packet >> msg;
@@ -172,11 +170,11 @@ bool handshakeRoleReq(uint32_t id,
 		          << "role. >:(" << std::endl;
 		return false;
 	}
-	
+
 	return true;
 }
-	
-bool connectToAndSyncWithServer(ClientRole roleID, 
+
+bool connectToAndSyncWithServer(ClientRole roleID,
                                 ClientRoleData &roleData,
                                 anax::World& world,
                                 Ogre::SceneManager *scene,
@@ -186,7 +184,7 @@ bool connectToAndSyncWithServer(ClientRole roleID,
 	if (sock_o.getLocalPort() == 0) {
 		if (!bindSocket('o', port_co)) {
 			std::cout << "Could not bind socket on port " << port_co
-			          << " to connect to and sync with server." 
+			          << " to connect to and sync with server."
 			          << std::endl;
 			return false;
 		}
@@ -202,7 +200,7 @@ bool connectToAndSyncWithServer(ClientRole roleID,
 
 	uint32_t id = handshakeHello(world, scene, system_gm);
 	if (id == NO_CLIENT_ID) {
-		std::cout << "The server didn't like us saying HELLO!" 
+		std::cout << "The server didn't like us saying HELLO!"
 		          << std::endl;
 		return false;
 	}

--- a/src/lib-tempo/src/network/server.cpp
+++ b/src/lib-tempo/src/network/server.cpp
@@ -19,9 +19,9 @@ namespace tempo
 std::map<uint32_t, tempo::clientConnection> clients;
 std::mutex cmtx;
 
-// For use in a separate thread by server to deal with a client so the main time 
+// For use in a separate thread by server to deal with a client so the main time
 // sync thread can continue listening for more clients whilst dealing with this.
-void timeSyncHandler(tempo::Clock *clock, sf::TcpSocket *client) 
+void timeSyncHandler(tempo::Clock *clock, sf::TcpSocket *client)
 {
 	std::cout << "Client (" << tcpRemoteToStr(client)
 	          << ") time sync started." << std::endl;
@@ -50,7 +50,7 @@ void timeSyncHandler(tempo::Clock *clock, sf::TcpSocket *client)
 	return;
 }
 
-void timeSyncServer(tempo::Clock *clock) 
+void timeSyncServer(tempo::Clock *clock)
 {
 	sf::TcpListener listener;
 	// Listen for a connection
@@ -59,7 +59,7 @@ void timeSyncServer(tempo::Clock *clock)
 		          << port_st << std::endl;
 		return;
 	}
-	
+
 	std::cout << "Time Sync Listener Started..." << std::endl;
 
 	std::vector<sf::TcpSocket*> clientSockets;
@@ -100,8 +100,8 @@ void timeSyncServer(tempo::Clock *clock)
 // Internal, should only be used when registering new clients.
 // Will not check if client already exists, just add the information as a new
 // client, so it is recommended to use `if (!findClientID(ip, port)) first!
-static uint32_t idCounter = NO_CLIENT_ID + 1; 
-uint32_t addClient(sf::Uint32 ip, 
+static uint32_t idCounter = NO_CLIENT_ID + 1;
+uint32_t addClient(sf::Uint32 ip,
                    unsigned short port,
                    ClientRole role = ClientRole::NO_ROLE)
 {
@@ -130,10 +130,10 @@ void handshakeHello(sf::Packet &packet,
 		id = findClientID(ip, updatePort);
 		// TODO: Time out old client and make a new one
 		std::cout << "WARNING: Connected client tried to reconnect ("
-		          << id << ", " << ip << ":" << updatePort << ")" 
+		          << id << ", " << ip << ":" << updatePort << ")"
 		          << std::endl;
 	}
-	
+
 	// Construct HELLO_ROG response
 	sf::Packet rog;
 	rog << static_cast<uint32_t>(HandshakeID::HELLO_ROG);
@@ -153,34 +153,33 @@ void handshakeHello(sf::Packet &packet,
 }
 
 void handshakeRoleReq(sf::Packet &packet,
-                      sf::IpAddress &sender, 
+                      sf::IpAddress &sender,
                       unsigned short port,
                       anax::World *world,
                       SystemLevelManager system_gm)
 {
 	// Extract data from packet
 	uint32_t id = NO_CLIENT_ID;
-	uint32_t role = static_cast<uint32_t>(ClientRole::NO_ROLE); 
+	uint32_t role = static_cast<uint32_t>(ClientRole::NO_ROLE);
 	ClientRoleData roleData;
-	packet >> id; // TODO change to temporary tocken	
+	packet >> id; // TODO change to temporary tocken
 	packet >> role;
-	packet >> roleData; 
+	packet >> roleData;
 
 	// Create Entity for selected role from client
-	// Only creating players for now (spectators are not a thing)	
+	// Only creating players for now (spectators are not a thing)
 	anax::Entity entity = newPlayer(*world, EID::EID_PLAYER, system_gm);
 
 	// Register Role
 	cmtx.lock();
 	clients[id].role = static_cast<ClientRole>(role);
 	cmtx.unlock();
-	
+
 	// Construct ROLEREQ_ROG response
 	sf::Packet rog;
 	rog << static_cast<uint32_t>(HandshakeID::ROLEREQ_ROG);
 	// TODO Package Requested Entity, eg:
 	EntityCreationData data = dumpEntity(entity);
-	printf("\n\ndata sending health : %d\n\n", data.entity_type.player.health);
 	rog << data;
 
 	sf::Packet p_broadcast;
@@ -190,12 +189,12 @@ void handshakeRoleReq(sf::Packet &packet,
 		if (client.first == id) continue;
 		sendMessage(tempo::SystemQID::ENTITY_CREATION, p_broadcast, client.first);
 	}
-	
+
 	//Send response back to sender
 	sock_h.send(rog, sender, port);
 }
 
-void processNewClientPacket(sf::Packet &packet, 
+void processNewClientPacket(sf::Packet &packet,
                             sf::IpAddress &sender,
                             unsigned short port,
                             anax::World *world,
@@ -207,7 +206,7 @@ void processNewClientPacket(sf::Packet &packet,
 	switch (static_cast<HandshakeID>(receiveID)) {
 	case HandshakeID::HELLO:
 		std::cout << "New client (" << sender.toString() << ":" << port
-		          << ") Connecting!" << std::endl; 
+		          << ") Connecting!" << std::endl;
 		handshakeHello(packet, sender, port, world);
 		break;
 	case HandshakeID::ROLEREQ:
@@ -215,7 +214,7 @@ void processNewClientPacket(sf::Packet &packet,
 		break;
 	default:
 		std::cout << "WARNING: an invalid handshake message was "
-		          << "recieved from " << sender.toString() << ":" 
+		          << "recieved from " << sender.toString() << ":"
 	                  << port << " ... ignoring" << std::endl;
 		break;
 	}
@@ -240,11 +239,11 @@ void listenForNewClients(anax::World *world, SystemLevelManager system_gm)
 
 		if (sock_h.receive(packet, ip, port) != sf::Socket::Done) {
 			std::cout << "Error recieving something from new "
-			          << "(connecting) client. Ignoring." 
+			          << "(connecting) client. Ignoring."
 			          << std::endl;
 			continue;
 		}
-	
+
 		processNewClientPacket(packet, ip, port, world, system_gm);
 	}
 
@@ -262,7 +261,7 @@ void listenForClientUpdates()
 		          << "listen for client updates." << std::endl;
 		return;
 	}
-	
+
 	std::cout << "Client Update Listener Started..." << std::endl;
 
 	sf::IpAddress ip;
@@ -278,7 +277,7 @@ void listenForClientUpdates()
 		// Sort packet into respective system.
 		sortPacket(packet);
 	}
-	
+
 	return;
 }
 
@@ -299,8 +298,8 @@ uint32_t findClientID(sf::Uint32 ip, unsigned short port)
 }
 
 
-bool sendMessage(tempo::SystemQID id, 
-                 sf::Packet payload, 
+bool sendMessage(tempo::SystemQID id,
+                 sf::Packet payload,
                  uint32_t client_id)
 {
 	sf::Packet message;

--- a/src/lib-tempo/src/network/server.cpp
+++ b/src/lib-tempo/src/network/server.cpp
@@ -142,9 +142,6 @@ void handshakeHello(sf::Packet &packet,
 	rog << port_st;
 	rog << static_cast<uint32_t>(world->getEntityCount());
 	for (auto& entity: world->getEntities()) {
-		if (!(entity.hasComponent<tempo::ComponentGridAi>()) && (entity.hasComponent<tempo::ComponentHealth>())) {
-			printf("\n\n\n Player being sent!!!! Health currently: %d", entity.getComponent<tempo::ComponentHealth>().current_health);
-		}
 		rog << dumpEntity(entity);
 	}
 

--- a/src/lib-tempo/src/network/server.cpp
+++ b/src/lib-tempo/src/network/server.cpp
@@ -142,6 +142,9 @@ void handshakeHello(sf::Packet &packet,
 	rog << port_st;
 	rog << static_cast<uint32_t>(world->getEntityCount());
 	for (auto& entity: world->getEntities()) {
+		if (!(entity.hasComponent<tempo::ComponentGridAi>()) && (entity.hasComponent<tempo::ComponentHealth>())) {
+			printf("\n\n\n Player being sent!!!! Health currently: %d", entity.getComponent<tempo::ComponentHealth>().current_health);
+		}
 		rog << dumpEntity(entity);
 	}
 
@@ -177,6 +180,7 @@ void handshakeRoleReq(sf::Packet &packet,
 	rog << static_cast<uint32_t>(HandshakeID::ROLEREQ_ROG);
 	// TODO Package Requested Entity, eg:
 	EntityCreationData data = dumpEntity(entity);
+	printf("\n\ndata sending health : %d\n\n", data.entity_type.player.health);
 	rog << data;
 
 	sf::Packet p_broadcast;

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -64,16 +64,12 @@ int main(int argc, const char** argv) {
 	world.refresh();
 
 	// YOLO
-	printf("\n Server AIs are being made \n\n");
-	anax::Entity entity_ai1 = tempo::newAI(world, tempo::EID_AI, 5, 5, 1000);
-	anax::Entity entity_ai2 = tempo::newAI(world, tempo::EID_AI, 3, 3, 1000);
-	anax::Entity entity_ai3 = tempo::newAI(world, tempo::EID_AI, 8, 8, 1000);
-	printf("\n Server AIs have been made \n\n");
+	anax::Entity entity_ai1 = tempo::newAI(world, tempo::EID_AI, 5, 5, 1000, 1000);
+	anax::Entity entity_ai2 = tempo::newAI(world, tempo::EID_AI, 3, 3, 1000, 1000);
+	anax::Entity entity_ai3 = tempo::newAI(world, tempo::EID_AI, 8, 8, 1000, 1000);
 
 	//Destroyables
-	anax::Entity entity_destroyable = tempo::newDestroyable(world, tempo::EID_DES, 2, 2, 200,200, "Cube");
-	printf("\n Server Destroyables have been made \n\n");
-
+	anax::Entity entity_destroyable = tempo::newDestroyable(world, tempo::EID_DES, 2, 2, 500,500, "Cube");
 
 	//NonDestroyables
 	anax::Entity entity_nondestroyable = tempo::newNonDestroyable(world, tempo::EID_NONDES, 5, 5, "Cube");
@@ -93,7 +89,6 @@ int main(int argc, const char** argv) {
 	while (true) {
 		if (clock.passed_beat()) {
 			system_grid_ai.update();
-			//system_health.HealthUpdate(-10);
 			/* std::cout << "Server Beat Passed (" */
 			/*           << clock.get_time().asSeconds() << ")" */
 			/*           << std::endl; */

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -64,12 +64,16 @@ int main(int argc, const char** argv) {
 	world.refresh();
 
 	// YOLO
-	anax::Entity entity_ai1 = tempo::newAI(world, tempo::EID_AI, 5, 5);
-	anax::Entity entity_ai2 = tempo::newAI(world, tempo::EID_AI, 3, 3);
-	anax::Entity entity_ai3 = tempo::newAI(world, tempo::EID_AI, 8, 8);
+	printf("\n Server AIs are being made \n\n");
+	anax::Entity entity_ai1 = tempo::newAI(world, tempo::EID_AI, 5, 5, 1000);
+	anax::Entity entity_ai2 = tempo::newAI(world, tempo::EID_AI, 3, 3, 1000);
+	anax::Entity entity_ai3 = tempo::newAI(world, tempo::EID_AI, 8, 8, 1000);
+	printf("\n Server AIs have been made \n\n");
 	
 	//Destroyables
-	anax::Entity entity_destroyable = tempo::newDestroyable(world, tempo::EID_DES, 2, 2, "Cube");
+	anax::Entity entity_destroyable = tempo::newDestroyable(world, tempo::EID_DES, 2, 2, 200, "Cube");
+	printf("\n Server Destroyables have been made \n\n");
+
 
 	//NonDestroyables
 	anax::Entity entity_nondestroyable = tempo::newNonDestroyable(world, tempo::EID_NONDES, 5, 5, "Cube");

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, const char** argv) {
 	anax::Entity entity_ai2 = tempo::newAI(world, tempo::EID_AI, 3, 3, 1000);
 	anax::Entity entity_ai3 = tempo::newAI(world, tempo::EID_AI, 8, 8, 1000);
 	printf("\n Server AIs have been made \n\n");
-	
+
 	//Destroyables
 	anax::Entity entity_destroyable = tempo::newDestroyable(world, tempo::EID_DES, 2, 2, 200, "Cube");
 	printf("\n Server Destroyables have been made \n\n");
@@ -106,8 +106,6 @@ int main(int argc, const char** argv) {
 		world.refresh();
 		system_level.update(dt);
 		system_health.HealthUpdate(-1);
-		int chealth = entity_ai1.getComponent<tempo::ComponentHealth>().current_health;
-		printf("\n\n AI current health = %d", chealth);
 		system_health.CheckHealth();
 		system_player_remote.update(system_id);
 		system_player_remote.advanceBeat();

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, const char** argv) {
 	printf("\n Server AIs have been made \n\n");
 
 	//Destroyables
-	anax::Entity entity_destroyable = tempo::newDestroyable(world, tempo::EID_DES, 2, 2, 200, "Cube");
+	anax::Entity entity_destroyable = tempo::newDestroyable(world, tempo::EID_DES, 2, 2, 200,200, "Cube");
 	printf("\n Server Destroyables have been made \n\n");
 
 
@@ -105,7 +105,6 @@ int main(int argc, const char** argv) {
 
 		world.refresh();
 		system_level.update(dt);
-		system_health.HealthUpdate(-1);
 		system_health.CheckHealth();
 		system_player_remote.update(system_id);
 		system_player_remote.advanceBeat();

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -93,7 +93,7 @@ int main(int argc, const char** argv) {
 	while (true) {
 		if (clock.passed_beat()) {
 			system_grid_ai.update();
-
+			//system_health.HealthUpdate(-10);
 			/* std::cout << "Server Beat Passed (" */
 			/*           << clock.get_time().asSeconds() << ")" */
 			/*           << std::endl; */
@@ -105,6 +105,9 @@ int main(int argc, const char** argv) {
 
 		world.refresh();
 		system_level.update(dt);
+		system_health.HealthUpdate(-1);
+		int chealth = entity_ai1.getComponent<tempo::ComponentHealth>().current_health;
+		printf("\n\n AI current health = %d", chealth);
 		system_health.CheckHealth();
 		system_player_remote.update(system_id);
 		system_player_remote.advanceBeat();


### PR DESCRIPTION
HealthComponent reattached to EntityCreation code, including passing _some_ data to the server.

Each Player, AI & Destroyable object has a `max_health` and `current_health`.

Players and AI have a health bar attached, destroyable objects currently do not. Changes to the materials would work better to show an increase in how damaged they are. (cracks, etc.)

**WORK NEEDED:**
Message passing from updateHealth function whenever the health changes. Currently, new players will have the most up-to-date health values, but current players do not receive updates.