### PR TITLE
Strict return for MSVC compiler

### DIFF
--- a/src/client/src/network/client.cpp
+++ b/src/client/src/network/client.cpp
@@ -246,6 +246,7 @@ bool connectToAndSyncWithServer(ClientRole roleID,
 bool broadcastMessage(QueueID id, sf::Packet p)
 {
 	assert(false); //I think this should nevevr happen
+	return false;
 }
 
 } // namespace tempo


### PR DESCRIPTION
Why not remove this if it should *nevevr* happen?