### PR TITLE
Camera Position Updated

### DIFF
--- a/src/client/include/client/misc/Lighting.hpp
+++ b/src/client/include/client/misc/Lighting.hpp
@@ -15,11 +15,13 @@ namespace client {
 
 	void createLasers(irr::scene::ISceneManager *smgr,
 					  irr::video::IVideoDriver * driver,
-					  std::vector<glm::ivec2> positions);
+					  std::vector<glm::ivec2> positions,
+					  glm::ivec2 playerPos);
 
 	void createDiscoBalls(irr::scene::ISceneManager *smgr,
 					  irr::video::IVideoDriver * driver,
 					  std::vector<glm::ivec2> positions,
+					  glm::ivec2 playerPos,
 					  irr::scene::ISceneNode *parent=0);
 }
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -288,37 +288,6 @@ int main(int argc, const char **argv)
 	auto &combo = entity_player.getComponent<tempo::ComponentCombo>().comboCounter;
 	auto &comp_health = entity_player.getComponent<tempo::ComponentHealth>();
 
-	irr::scene::ICameraSceneNode *camera_node;
-	if (false) {
-		float rotateSpeed = 25.0f;
-		float moveSpeed   = 0.1f;
-		camera_node       = smgr->addCameraSceneNodeFPS(nullptr, rotateSpeed, moveSpeed);
-		device->getCursorControl()->setVisible(false);
-	} else {
-		float rotate    = 0.0f;
-		float translate = 0.0f;  //-100
-		float zoom      = 0.0f;  // 100
-		float distance  = 0.0f;
-		// camera_node = smgr->addCameraSceneNodeMaya(sn.node, rotate, translate, zoom, -1,
-		// distance); camera_node->setPosition(irr::core::vector3df(0.0f, 0.0f, 0.0f));
-		camera_node = smgr->addCameraSceneNode();
-		camera_node->setPosition(irr::core::vector3df(14, 9, 0));
-		camera_node->setTarget(sn.node->getPosition());
-		// camera_node->setRotation(irr::core::vector3df(0,0,90));
-		device->getCursorControl()->setVisible(true);
-	}
-
-	// irr::scene::ISceneNode* camera_light;
-	// camera_light = smgr->addLightSceneNode(camera_node,
-	//                                        irr::core::vector3df(0.0f, 4.0f, 0.0f),
-	//                                        irr::video::SColorf(0.8f, 0.8f, 0.8f),
-	//                                        2.0f);
-	// debug static light
-	// irr::scene::ILightSceneNode *light_node;
-	// light_node = smgr->addLightSceneNode(0, irr::core::vector3df(10.0f, 10.0f, 10.0f),
-	//                                      irr::video::SColorf(0.8f, 0.8f, 0.8f), 5.0f);
-	// irr::video::SLight& light_data = light_node->getLightData();
-
 	client::createLasers(smgr, driver, { {40,12}, {40,52}, {40,92} });
 
 	client::createDiscoBalls(smgr, driver, { {40,6} });
@@ -384,8 +353,10 @@ int main(int argc, const char **argv)
 			system_render_healing.update();
 
 			// TODO: Make a system for updating camera position
+			irr::scene::ICameraSceneNode *camera_node;
+			camera_node = smgr->addCameraSceneNode();
 			irr::core::vector3df camera_target = sn.node->getAbsolutePosition();
-			camera_node->setPosition(camera_target + irr::core::vector3df(14, 9, 0));
+			camera_node->setPosition(camera_target + irr::core::vector3df(7, 9, 0));
 			camera_node->updateAbsolutePosition();
 			camera_node->setTarget(camera_target);
 		}

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -288,9 +288,11 @@ int main(int argc, const char **argv)
 	auto &combo = entity_player.getComponent<tempo::ComponentCombo>().comboCounter;
 	auto &comp_health = entity_player.getComponent<tempo::ComponentHealth>();
 
-	client::createLasers(smgr, driver, { {40,12}, {40,52}, {40,92} });
+	glm::ivec2 startingPos = entity_player.getComponent<tempo::ComponentStagePosition>().getOrigin();
 
-	client::createDiscoBalls(smgr, driver, { {40,6} });
+	client::createLasers(smgr, driver, { {40,12}, {40,52}, {40,92} }, startingPos);
+
+	client::createDiscoBalls(smgr, driver, { {40,6} }, startingPos);
 
 	/////////////////////////////////////////////////
 	// Main loop

--- a/src/client/src/misc/Lighting.cpp
+++ b/src/client/src/misc/Lighting.cpp
@@ -5,7 +5,8 @@ namespace client {
 
 	void createLasers(irr::scene::ISceneManager *smgr,
 					  irr::video::IVideoDriver * driver,
-					  std::vector<glm::ivec2> positions) {
+					  std::vector<glm::ivec2> positions,
+					  glm::ivec2 playerPos) {
 
 		irr::core::array<irr::video::ITexture*> texturesLaser;
 
@@ -18,6 +19,10 @@ namespace client {
 		};
 
 		for (glm::ivec2 pos : positions) {
+
+			if (pos.x < playerPos.x - 20 || pos.x > playerPos.x + 20) {
+				continue;
+			}
 
 			irr::scene::IVolumeLightSceneNode* nodeLaserA[10];
 
@@ -88,11 +93,23 @@ namespace client {
 	void createDiscoBalls(irr::scene::ISceneManager *smgr,
 						  irr::video::IVideoDriver * driver,
 						  std::vector<glm::ivec2> positions,
+						  glm::ivec2 playerPos,
 						  irr::scene::ISceneNode *parent) {
 
-		irr::scene::IAnimatedMeshSceneNode* nodeDiscoBall1 = smgr->addAnimatedMeshSceneNode(smgr->getMesh("resources/meshes/disco_ball.obj"), parent);
+		irr::scene::IAnimatedMeshSceneNode* nodeDiscoBall1;
+
+		bool created = false;
 
 		for (glm::ivec2 pos : positions) {
+
+			if (pos.x < playerPos.x - 20 || pos.x > playerPos.x + 20) {
+				continue;
+			}
+
+			if (!created) {
+				nodeDiscoBall1 = smgr->addAnimatedMeshSceneNode(smgr->getMesh("resources/meshes/disco_ball.obj"), parent);
+				created = true;
+			}
 
 			nodeDiscoBall1->setPosition(irr::core::vector3df(pos.x, 10, pos.y));
 			// nodeDiscoBall1->setRotation(vector3df(0, 180, 0));

--- a/src/client/src/system/SystemStageRenderer.cpp
+++ b/src/client/src/system/SystemStageRenderer.cpp
@@ -121,8 +121,8 @@ void SystemStageRenderer::updateStage(irr::scene::ISceneManager *smgr,
 		float height = heights[i].height;
 
 		// Stop logic on tiles that are not visible to camera
-		if (pos.y < playerpos.x - 30 || pos.y > playerpos.x + 13 || pos.x < playerpos.y - 30
-		    || pos.x > playerpos.y + 30) {
+		if (pos.y < playerpos.x - 24 || pos.y > playerpos.x + 7 || pos.x < playerpos.y - 33
+		    || pos.x > playerpos.y + 33) {
 			continue;
 		}
 


### PR DESCRIPTION
The camera has now been moved to a new position.

Also:
- The 'logic boundaries' for the updating colour tiles has also been updated and so now you won't see walls just popping in and out of gameplay.
- The rendering of lasers and disco balls has also been restricted to a set distance away from the players starting location. This is so that when we have feeder areas we remove the chance of seeing them randomly in the distance.