### PR TITLE
Players move back to spawnpoint on death

### DIFF
--- a/src/lib-tempo/include/tempo/system/SystemHealth.hpp
+++ b/src/lib-tempo/include/tempo/system/SystemHealth.hpp
@@ -4,6 +4,8 @@
 #include <anax/System.hpp>
 
 #include <tempo/component/ComponentHealth.hpp>
+#include <tempo/component/ComponentPlayerRemote.hpp>
+#include <tempo/component/ComponentPlayerLocal.hpp>
 #include <tempo/network/base.hpp>
 #include <tempo/network/ID.hpp>
 #include <tempo/network/queue.hpp>

--- a/src/lib-tempo/src/system/SystemHealth.cpp
+++ b/src/lib-tempo/src/system/SystemHealth.cpp
@@ -17,9 +17,22 @@ void SystemHealth::CheckHealth()
 		if ((h.current_health <= 0)) {
 			// printf("\nEntity ID: %ld has just been \"killed\". \n", id.index);
 			// This got too annoying
-			if (entity.hasComponent<ComponentStagePosition>()) {
-				entity.getComponent<ComponentStagePosition>().movePosition(
-				  glm::ivec2(1000, 1000));  // poof
+			if (entity.hasComponent<ComponentPlayerRemote>() ||
+			    entity.hasComponent<ComponentPlayerLocal>())
+			{
+				if (entity.hasComponent<ComponentStagePosition>()) {
+					entity.getComponent<ComponentStagePosition>().setPosition(
+					  glm::ivec2(40, 7));  // poof
+					h.current_health = h.max_health;
+				}
+			}
+			else
+			{
+				if (entity.hasComponent<ComponentStagePosition>()) {
+					entity.getComponent<ComponentStagePosition>().setPosition(
+					  glm::ivec2(1000, 1000));  // poof
+					h.current_health = h.max_health;
+				}
 			}
 			// entity.deactivate();
 		}


### PR DESCRIPTION
Quick change so that death is less painful. Currently camera position doesn't quite update properly, but I'm not sure why