### PR TITLE
Jt/data capture client

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -12,3 +12,6 @@ UnitTests
 
 # Irrlicht examples and tools
 /irrlicht/
+
+# Client output
+client_input_*

--- a/src/client/include/client/system/SystemParseKeyInput.hpp
+++ b/src/client/include/client/system/SystemParseKeyInput.hpp
@@ -7,11 +7,27 @@
 #include <client/component/ComponentKeyInput.hpp>
 
 #include <tempo/time.hpp>
-#include <IrrlichtDevice.h> 
+#include <IrrlichtDevice.h>
+
+#define TEMPO_DATA_CAPTURE 1
+
+#ifdef TEMPO_DATA_CAPTURE
+#include <fstream>
+#endif
 
 namespace client
 {
 struct SystemParseKeyInput : anax::System<anax::Requires<ComponentKeyInput>> {
+	#ifdef TEMPO_DATA_CAPTURE
+	std::ofstream data_output;
+	#endif
+
+	// Sets up the system, opens the data_output file
+	SystemParseKeyInput();
+
+	// Closes the data_output file
+	~SystemParseKeyInput();
+
 	void parseInput(tempo::Clock &clock, irr::IrrlichtDevice* device);
 };
 

--- a/src/client/src/network/client.cpp
+++ b/src/client/src/network/client.cpp
@@ -24,7 +24,7 @@ sf::Int64 timeSyncClient(tempo::Clock *clock)
 	// Initialise time sync protocol variables
 	sf::Int64 T1  = 0;  // PACKET: Previous packet time of departure
 	sf::Int64 T2  = 0;  // PACKET: Previous packet time of arrival
-	sf::Int64 T3  = 0;  // PACKET: Current pakcet time of departure
+	sf::Int64 T3  = 0;  // PACKET: Current packet time of departure
 	sf::Int64 T4  = 0;  // PACKET: Current packet time of arrival
 	sf::Int64 org = 0;  // STATE:  Time when message departed from peer
 	// sf::Int64 rec    = 0; // STATE:  Time when we received from the peer

--- a/src/client/src/system/SystemParseKeyInput.cpp
+++ b/src/client/src/system/SystemParseKeyInput.cpp
@@ -207,7 +207,7 @@ SystemParseKeyInput::SystemParseKeyInput(){
 	printf("SystemParseKeyInput is opening input dump file: '%s'\n", filename.c_str());
 
 	this->data_output.open(filename);
-	this->data_output << "BeatNumber, OnBeat, BeatDiff, UntilBeat, Key" << std::endl;
+	this->data_output << "BeatNumber, OnBeat, BeatDiff, Key" << std::endl;
 	#endif
 }
 

--- a/src/client/src/system/SystemParseKeyInput.cpp
+++ b/src/client/src/system/SystemParseKeyInput.cpp
@@ -18,6 +18,8 @@
 #include <glm/vec2.hpp>
 
 #include <iostream>
+#include <ctime>
+#include <string>
 
 namespace client
 {
@@ -182,6 +184,38 @@ void processKeyPressEvent(irr::EKEY_CODE key, anax::Entity &entity, bool withinD
 		break;
 	default: break;
 	}
+}
+
+
+SystemParseKeyInput::SystemParseKeyInput(){
+	#ifdef TEMPO_DATA_CAPTURE
+
+	char datetime_cstring[80];
+	time_t rawtime;
+	struct tm* timeinfo;
+
+	time(&rawtime);
+	timeinfo = localtime(&rawtime);
+
+	strftime(datetime_cstring, sizeof(datetime_cstring),
+	         "%Y-%m-%d_%I:%M:%S", timeinfo
+	        );
+
+	std::string filename = (std::string("client_input_" ) +
+	                        std::string(datetime_cstring) +
+	                        std::string(".dat"));
+
+	printf("SystemParseKeyInput is opening input dump file: '%s'\n", filename.c_str());
+
+
+	this->data_output.open(filename);
+	#endif
+}
+
+SystemParseKeyInput::~SystemParseKeyInput(){
+	#ifdef TEMPO_DATA_CAPTURE
+	this->data_output.close();
+	#endif
 }
 
 void SystemParseKeyInput::parseInput(tempo::Clock &clock, irr::IrrlichtDevice* device)

--- a/src/client/src/system/SystemParseKeyInput.cpp
+++ b/src/client/src/system/SystemParseKeyInput.cpp
@@ -189,7 +189,6 @@ void processKeyPressEvent(irr::EKEY_CODE key, anax::Entity &entity, bool withinD
 
 SystemParseKeyInput::SystemParseKeyInput(){
 	#ifdef TEMPO_DATA_CAPTURE
-
 	char datetime_cstring[80];
 	time_t rawtime;
 	struct tm* timeinfo;
@@ -207,8 +206,8 @@ SystemParseKeyInput::SystemParseKeyInput(){
 
 	printf("SystemParseKeyInput is opening input dump file: '%s'\n", filename.c_str());
 
-
 	this->data_output.open(filename);
+	this->data_output << "BeatNumber, OnBeat, BeatDiff, UntilBeat, Key" << std::endl;
 	#endif
 }
 
@@ -229,6 +228,19 @@ void SystemParseKeyInput::parseInput(tempo::Clock &clock, irr::IrrlichtDevice* d
 
 		for (unsigned int i = 0; i < ke.keysPressed.size(); i++) {
 			if (ke.keysPressed[i].press) {
+				#ifdef TEMPO_DATA_CAPTURE
+
+				float since_beat = clock.since_beat().asSeconds();
+				float until_beat = clock.until_beat().asSeconds();
+
+				float delta = clock.beat_progress() < 0.5 ? since_beat : -until_beat;
+
+				this->data_output << clock.get_beat_number()        << ", "
+				                  << (withinDelta ? '1' : '0')      << ", "
+				                  << delta                          << ", "
+				                  << ke.keysPressed[i].key          << std::endl;
+				#endif
+
 				processKeyPressEvent(ke.keysPressed[i].key, entity, withinDelta, device);
 			}
 		}

--- a/src/client/src/system/SystemParseKeyInput.cpp
+++ b/src/client/src/system/SystemParseKeyInput.cpp
@@ -201,7 +201,7 @@ SystemParseKeyInput::SystemParseKeyInput(){
 
 	std::string filename = (std::string("client_input_" ) +
 	                        std::string(datetime_cstring) +
-	                        std::string(".dat"));
+	                        std::string(".csv"));
 
 	printf("SystemParseKeyInput is opening input dump file: '%s'\n", filename.c_str());
 

--- a/src/lib-tempo/include/tempo/time.hpp
+++ b/src/lib-tempo/include/tempo/time.hpp
@@ -44,7 +44,7 @@ class Clock
 	sf::Time get_time();
 	void     set_time(sf::Time t);
 
-	// Checks to see if we have passed the beat as marked by "Beat Passed", 
+	// Checks to see if we have passed the beat as marked by "Beat Passed",
 	// "Midpoint of 2 beats", "Delta Start" and "Delta End" in Figure 1.
 	// Returns true if so. Will return false after returning true
 	// (i.e. a beat passing), until the next beat passes.
@@ -77,6 +77,9 @@ class Clock
 	// period as per Figure 1.
 	bool within_delta();
 
+	// Retrieves the number of beats passed since the creation of this clock
+	unsigned int get_beat_number();
+
    private:
 	// Cached time and our underlying clock
 	sf::Time  time;
@@ -96,6 +99,9 @@ class Clock
 	bool passed_ab;
 	bool passed_ds;
 	bool passed_de;
+
+	// The number of beats that have passed so far since the creation of this clock
+	unsigned int beat_number;
 
 	// Caches the internal time
 	void cache_time();

--- a/src/lib-tempo/include/tempo/time.hpp
+++ b/src/lib-tempo/include/tempo/time.hpp
@@ -68,6 +68,12 @@ class Clock
 	// Returns time until the next delta start event as in Figure 1
 	sf::Time until_delta_start();
 
+	// Retrieves the size of the window to either side of the beat within which
+	// actions may be performed
+	// Note that it is this much time before AND after the beat within which
+	// actions can be performed
+	sf::Time get_beat_window_delta();
+
 	// Sets when the next beat should be. The time given is an
 	// absolute time. From this point on the beats will continue to
 	// progress with a time between beats of (next_beat - last_beat)

--- a/src/lib-tempo/src/time.cpp
+++ b/src/lib-tempo/src/time.cpp
@@ -11,6 +11,7 @@ Clock::Clock(sf::Time first_beat, sf::Time delta)
 	passed_de   = false;
 	next_beat   = first_beat;
 	last_beat   = sf::Time::Zero;
+	beat_number = 0;
 	this->delta = delta;
 }
 
@@ -113,6 +114,7 @@ void Clock::update_beat()
 {
 	cache_time();
 	while (next_beat < time) {
+		++this->beat_number;
 		sf::Time beat_length = next_beat - last_beat;
 		last_beat            = next_beat;
 		next_beat            = last_beat + beat_length;
@@ -120,5 +122,9 @@ void Clock::update_beat()
 	passed_ds = false;
 	passed_de = false;
 	passed_ab = false;
+}
+
+unsigned int Clock::get_beat_number(){
+	return this->beat_number;
 }
 }

--- a/src/lib-tempo/src/time.cpp
+++ b/src/lib-tempo/src/time.cpp
@@ -67,6 +67,10 @@ bool Clock::passed_delta_end()
 	return false;
 }
 
+sf::Time Clock::get_beat_window_delta(){
+	return this->delta;
+}
+
 float Clock::beat_progress()
 {
 	return since_beat() / (since_beat() + until_beat());


### PR DESCRIPTION
This is a fairly basic version of data capturing - client just writes some stats to a csv each time a key is pressed.

I'm not convinced this will be enough data to replay a game after it has happened, since we cant guarentee network latencies are the same, so intents may arrive at the server at different times causing different results and hence the game state of the replay to slowly diverge from that of the original play session.

Regardless, this data should allow us to answer questions like:
- What percentage of key presses were on beat?
- How many beats were missed?
- How many beats did the user try to move twice?
- etc

I think it would be useful to correlate the collected data with the user survey response, then we can plot reported game satisfaction against how well the player stayed on beat. @Codrin-Popa (I think you made the form) Any way we can add a file upload to the google docs form to upload the output csv? Alternativey the csv files are labelled with the datetime that the client was started, so could just add a box for us to fill in with that - but we'd need to get the children to only fill in their boxes and then us add the extra data.

Also, would it be useful to have slightly different windows within which the user can press the button (eg, 80ms, 100ms, 120ms, 140ms or something) then correlate stats from these data files like how well the player stayed on beat with those window sizes. Additionally we could correlate the subjective "how fun is this game" rating with the window size. If so we would need to add that to the google form as well.