### PR TITLE
Cp/optimisations

### DIFF
--- a/src/client/include/client/system/SystemRenderSpikes.hpp
+++ b/src/client/include/client/system/SystemRenderSpikes.hpp
@@ -20,7 +20,7 @@ class SystemRenderSpikes
    public:
 	void setup(irr::scene::ISceneManager *smgr, irr::video::IVideoDriver *driver);
 
-	void updateSpikes(irr::video::IVideoDriver *driver);
+	void updateSpikes(irr::video::IVideoDriver *driver, const glm::ivec2 playerpos);
 };
 }  // namespace client
 

--- a/src/client/include/client/system/SystemStageRenderer.hpp
+++ b/src/client/include/client/system/SystemStageRenderer.hpp
@@ -75,6 +75,14 @@ class SystemStageRenderer : public anax::System<anax::Requires<tempo::ComponentS
 	            irr::video::IVideoDriver  *driver,
 	            glm::ivec2                 playerpos);
 
+void Update(irr::scene::ISceneManager *smgr,
+            irr::video::IVideoDriver * driver,
+            glm::ivec2                 playerpos,
+            irr::video::SColor         C1,
+            irr::video::SColor         C2,
+            int                        step,
+            float                      dt);
+
 	void colorStage(int                        j,
                         glm::ivec2                 playerpos,
 	                irr::video::SColor         C1,

--- a/src/client/include/client/system/SystemStageRenderer.hpp
+++ b/src/client/include/client/system/SystemStageRenderer.hpp
@@ -11,6 +11,7 @@
 #include <ISceneManager.h>
 #include <IVideoDriver.h>
 #include <vector>
+#include <unordered_map>
 
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
@@ -27,6 +28,19 @@ struct vec2less
 	{
 		return (a.x < b.x) || ((a.x == b.x) && (a.y < b.y));
 	}
+};
+
+struct vec2eq
+{
+    size_t operator()(const glm::ivec2& k)const
+    {
+        return std::hash<int>()(k.x) ^ std::hash<int>()(k.y);
+    }
+
+    bool operator()(const glm::ivec2& a, const glm::ivec2& b)const
+    {
+            return a.x == b.x && a.y == b.y;
+    }
 };
 
 typedef struct {
@@ -48,8 +62,8 @@ class SystemStageRenderer : public anax::System<anax::Requires<tempo::ComponentS
 	irr::scene::IMesh *         walls;
 	irr::scene::CBatchingMesh * batchMesh;
 
-	std::map<glm::ivec2, tile_t, 
-	         vec2less, std::allocator<std::pair<const glm::ivec2, tile_t>>> tileMap;
+	std::unordered_map<glm::ivec2, tile_t,
+	         vec2eq, vec2eq, std::allocator<std::pair<const glm::ivec2, tile_t>>> tileMap;
 
 	std::map<irr::video::SColor, irr::scene::IMesh*> meshMap;
 

--- a/src/client/include/client/system/SystemStageRenderer.hpp
+++ b/src/client/include/client/system/SystemStageRenderer.hpp
@@ -80,7 +80,7 @@ class SystemStageRenderer : public anax::System<anax::Requires<tempo::ComponentS
 	                irr::video::SColor         C1,
 	                irr::video::SColor         C2);
 
-	void AnimateTiles(float dt);
+	void AnimateTiles(float dt, glm::ivec2 playerpos);
 
 	void setTileColor(glm::ivec2 pos, irr::video::SColor color);
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -420,7 +420,7 @@ int main(int argc, const char** argv)
 			playerpos =
 				entity_player.getComponent<tempo::ComponentStagePosition>().getOrigin();
 
-			system_stage_renderer.colorStage(j, playerpos, random_colour, colour_grey);
+			//system_stage_renderer.colorStage(j, playerpos, random_colour, colour_grey);
 
 			// Check for new entities from server
 			system_entity.creationCheck(world);
@@ -518,12 +518,13 @@ int main(int argc, const char** argv)
 		// std::clock_t    start;
 		//
 		// 				start = std::clock();
-		system_stage_renderer.AnimateTiles(dt, playerpos);
+		//system_stage_renderer.AnimateTiles(dt, playerpos);
 		// std::cout << "Time: " << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) << " ms" << std::endl;
 
+		system_stage_renderer.Update(smgr, driver, playerpos, random_colour, colour_grey, j, dt);
 
 
-		system_stage_renderer.Update(smgr, driver, playerpos);
+		//system_stage_renderer.Update(smgr, driver, playerpos);
 
 
 		driver->beginScene(true, true);

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -390,13 +390,13 @@ int main(int argc, const char** argv)
 
 	client::ComponentRenderSceneNode& sn = entity_player.getComponent<client::ComponentRenderSceneNode>();
 	irr::scene::ICameraSceneNode *camera_node = new irr::scene::Camera(
-		sn.node, 
-		smgr, 
-		-1, 
-		irr::core::vector3df(7, 7, 0), 
+		sn.node,
+		smgr,
+		-1,
+		irr::core::vector3df(7, 7, 0),
 		irr::core::vector3df(0, 0, 0));
 	//irr::core::matrix4 cpm = camera_node->getProjectionMatrix();
-	
+
 	//camera_node->setFOV(1.0f);
 
 	smgr->setActiveCamera(camera_node);
@@ -405,6 +405,7 @@ int main(int argc, const char** argv)
 
 	printf("Entering main loop\n");
 	while (device->run()) {
+
 
 		// Work out a frame delta time.
 		// const irr::u32 now = device->getTimer()->getTime();
@@ -513,8 +514,17 @@ int main(int argc, const char** argv)
 			system_combo.advanceBeat();
 		}
 
+
+		// std::clock_t    start;
+		//
+		// 				start = std::clock();
 		system_stage_renderer.AnimateTiles(dt);
+		// std::cout << "Time: " << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) << " ms" << std::endl;
+
+
+
 		system_stage_renderer.Update(smgr, driver, playerpos);
+
 
 		driver->beginScene(true, true);
 		smgr->drawAll();

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -518,7 +518,7 @@ int main(int argc, const char** argv)
 		// std::clock_t    start;
 		//
 		// 				start = std::clock();
-		system_stage_renderer.AnimateTiles(dt);
+		system_stage_renderer.AnimateTiles(dt, playerpos);
 		// std::cout << "Time: " << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) << " ms" << std::endl;
 
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -74,7 +74,7 @@ namespace client
 	 	>
 	 {
 	 public:
-	 	void lessJank() {
+	 	void lessJank(const glm::ivec2 playerpos) {
 	 		// uncomment this for more jank:
 	 		//return;
 
@@ -85,7 +85,11 @@ namespace client
 	 			tempo::ComponentStage& stage = entity.getComponent<tempo::ComponentStage>();
 	 			glm::ivec2 origin = entity.getComponent<tempo::ComponentStagePosition>().getOrigin();
 
-
+				if (origin.x < playerpos.x - 24 || origin.x > playerpos.x + 7 ||
+				    origin.y < playerpos.y - 33 || origin.y > playerpos.y + 33)
+				{
+					continue;
+				}
 
 	 			glm::ivec2 dest = origin + trans.delta;
 
@@ -449,7 +453,7 @@ int main(int argc, const char** argv)
 			system_health.check_health();
 			system_health.client_receiveHealth(world);
 
-			system_less_jank.lessJank();
+			system_less_jank.lessJank(playerpos);
 			// Update animations from translations received from server
 			system_translation_animation.updateAnimations();
 

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -486,7 +486,7 @@ int main(int argc, const char** argv)
 			system_button_renderer.updateButtons(driver);
 
 			system_render_healing.endBeat();
-			system_render_spikes.updateSpikes(driver);
+			system_render_spikes.updateSpikes(driver, playerpos);
 
 			system_translation_animation.endBeat();
 

--- a/src/client/src/misc/Lighting.cpp
+++ b/src/client/src/misc/Lighting.cpp
@@ -102,7 +102,7 @@ namespace client {
 		irr::scene::IAnimatedMesh *disco_ball_mesh = smgr->getMesh("resources/meshes/disco_ball.obj");
 		irr::video::ITexture* disco_ball_texture = driver->getTexture("resources/materials/disco_ball.jpg");
 		irr::video::ITexture* reflexes_texture = driver->getTexture("resources/materials/reflexes.jpg");
-		//irr::video::ITexture* estrela_texture = driver->getTexture("resources/materials/estrela_squared.png");
+		irr::video::ITexture* estrela_texture = driver->getTexture("resources/materials/estrela_squared.png");
 
 		for (glm::ivec2 pos : positions) {
 
@@ -152,7 +152,7 @@ namespace client {
 			nodeDiscoBall1->addAnimator(anim11);
 			anim11->drop();
 
-			/ Create particle system: (DISCO BALL N1 - reflexed lights)
+			// Create particle system: (DISCO BALL N1 - reflexed lights)
 			irr::scene::IParticleSystemSceneNode* ps60 = smgr->addParticleSystemSceneNode(false);
 
 			irr::scene::IParticleEmitter* em60 = ps60->createSphereEmitter( /// SPHERE Emitter (Same geometry as the mesh is)

--- a/src/client/src/misc/Lighting.cpp
+++ b/src/client/src/misc/Lighting.cpp
@@ -102,7 +102,7 @@ namespace client {
 		irr::scene::IAnimatedMesh *disco_ball_mesh = smgr->getMesh("resources/meshes/disco_ball.obj");
 		irr::video::ITexture* disco_ball_texture = driver->getTexture("resources/materials/disco_ball.jpg");
 		irr::video::ITexture* reflexes_texture = driver->getTexture("resources/materials/reflexes.jpg");
-		irr::video::ITexture* estrela_texture = driver->getTexture("resources/materials/estrela_squared.png");
+		//irr::video::ITexture* estrela_texture = driver->getTexture("resources/materials/estrela_squared.png");
 
 		for (glm::ivec2 pos : positions) {
 
@@ -153,34 +153,34 @@ namespace client {
 			anim11->drop();
 
 			/// Create particle system: (DISCO BALL N1 - reflexed lights)
-			irr::scene::IParticleSystemSceneNode* ps60 = smgr->addParticleSystemSceneNode(false);
-
-			irr::scene::IParticleEmitter* em60 = ps60->createSphereEmitter( /// SPHERE Emitter (Same geometry as the mesh is)
-				irr::core::vector3df(0.0f, 0.0f, 0.0f),  // emitter position
-				0.282f,                           // f32 radius
-				irr::core::vector3df(0.0f, 0.0f, 0.0f),  // initial direction & speed (all set to 0.0f == particles stopped)
-				0, 0,                              // minParticlesPerSecond / maxParticlesPerSecond (Will change in main loop)
-												   // video::SColor(0,0,0,255),      // darkest color
-				irr::video::SColor(0, 0, 0, 0),           // darkest color
-				irr::video::SColor(255, 255, 255, 255),   // brightest color
-				90, 200, 0,                         // min age, max age, angle
-				irr::core::dimension2df(1.0f, 1.0f),  // min size
-				irr::core::dimension2df(1.5f, 1.5f)); // max size
-
-			ps60->setEmitter(em60); // Grabs the emitter
-			em60->drop(); // We can drop it here, without deleting it
-
-			ps60->setParent(nodeDiscoBall1); /// Attach these reflexed lights to the Disco Ball N1 (Match to the same position & rotation)
-			ps60->setScale(irr::core::vector3df(41, 41, 41));
-			ps60->setMaterialFlag(irr::video::EMF_ZWRITE_ENABLE, false);
-			ps60->setMaterialTexture(0, estrela_texture);
-			ps60->setMaterialType(irr::video::EMT_TRANSPARENT_ALPHA_CHANNEL); // Transparent texture.
-			ps60->setMaterialFlag(irr::video::EMF_LIGHTING, true); // Node is affected by LIGHT?
-			ps60->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
-
-			/// Disabled:
-			em60->setMinParticlesPerSecond(90);
-			em60->setMaxParticlesPerSecond(100);
+			// irr::scene::IParticleSystemSceneNode* ps60 = smgr->addParticleSystemSceneNode(false);
+			//
+			// irr::scene::IParticleEmitter* em60 = ps60->createSphereEmitter( /// SPHERE Emitter (Same geometry as the mesh is)
+			// 	irr::core::vector3df(0.0f, 0.0f, 0.0f),  // emitter position
+			// 	0.282f,                           // f32 radius
+			// 	irr::core::vector3df(0.0f, 0.0f, 0.0f),  // initial direction & speed (all set to 0.0f == particles stopped)
+			// 	0, 0,                              // minParticlesPerSecond / maxParticlesPerSecond (Will change in main loop)
+			// 									   // video::SColor(0,0,0,255),      // darkest color
+			// 	irr::video::SColor(0, 0, 0, 0),           // darkest color
+			// 	irr::video::SColor(255, 255, 255, 255),   // brightest color
+			// 	90, 200, 0,                         // min age, max age, angle
+			// 	irr::core::dimension2df(1.0f, 1.0f),  // min size
+			// 	irr::core::dimension2df(1.5f, 1.5f)); // max size
+			//
+			// ps60->setEmitter(em60); // Grabs the emitter
+			// em60->drop(); // We can drop it here, without deleting it
+			//
+			// ps60->setParent(nodeDiscoBall1); /// Attach these reflexed lights to the Disco Ball N1 (Match to the same position & rotation)
+			// ps60->setScale(irr::core::vector3df(41, 41, 41));
+			// ps60->setMaterialFlag(irr::video::EMF_ZWRITE_ENABLE, false);
+			// ps60->setMaterialTexture(0, estrela_texture);
+			// ps60->setMaterialType(irr::video::EMT_TRANSPARENT_ALPHA_CHANNEL); // Transparent texture.
+			// ps60->setMaterialFlag(irr::video::EMF_LIGHTING, true); // Node is affected by LIGHT?
+			// ps60->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
+			//
+			// /// Disabled:
+			// em60->setMinParticlesPerSecond(90);
+			// em60->setMaxParticlesPerSecond(100);
 		}
 
 	}

--- a/src/client/src/misc/Lighting.cpp
+++ b/src/client/src/misc/Lighting.cpp
@@ -152,35 +152,35 @@ namespace client {
 			nodeDiscoBall1->addAnimator(anim11);
 			anim11->drop();
 
-			/// Create particle system: (DISCO BALL N1 - reflexed lights)
-			// irr::scene::IParticleSystemSceneNode* ps60 = smgr->addParticleSystemSceneNode(false);
-			//
-			// irr::scene::IParticleEmitter* em60 = ps60->createSphereEmitter( /// SPHERE Emitter (Same geometry as the mesh is)
-			// 	irr::core::vector3df(0.0f, 0.0f, 0.0f),  // emitter position
-			// 	0.282f,                           // f32 radius
-			// 	irr::core::vector3df(0.0f, 0.0f, 0.0f),  // initial direction & speed (all set to 0.0f == particles stopped)
-			// 	0, 0,                              // minParticlesPerSecond / maxParticlesPerSecond (Will change in main loop)
-			// 									   // video::SColor(0,0,0,255),      // darkest color
-			// 	irr::video::SColor(0, 0, 0, 0),           // darkest color
-			// 	irr::video::SColor(255, 255, 255, 255),   // brightest color
-			// 	90, 200, 0,                         // min age, max age, angle
-			// 	irr::core::dimension2df(1.0f, 1.0f),  // min size
-			// 	irr::core::dimension2df(1.5f, 1.5f)); // max size
-			//
-			// ps60->setEmitter(em60); // Grabs the emitter
-			// em60->drop(); // We can drop it here, without deleting it
-			//
-			// ps60->setParent(nodeDiscoBall1); /// Attach these reflexed lights to the Disco Ball N1 (Match to the same position & rotation)
-			// ps60->setScale(irr::core::vector3df(41, 41, 41));
-			// ps60->setMaterialFlag(irr::video::EMF_ZWRITE_ENABLE, false);
-			// ps60->setMaterialTexture(0, estrela_texture);
-			// ps60->setMaterialType(irr::video::EMT_TRANSPARENT_ALPHA_CHANNEL); // Transparent texture.
-			// ps60->setMaterialFlag(irr::video::EMF_LIGHTING, true); // Node is affected by LIGHT?
-			// ps60->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
-			//
-			// /// Disabled:
-			// em60->setMinParticlesPerSecond(90);
-			// em60->setMaxParticlesPerSecond(100);
+			/ Create particle system: (DISCO BALL N1 - reflexed lights)
+			irr::scene::IParticleSystemSceneNode* ps60 = smgr->addParticleSystemSceneNode(false);
+
+			irr::scene::IParticleEmitter* em60 = ps60->createSphereEmitter( /// SPHERE Emitter (Same geometry as the mesh is)
+				irr::core::vector3df(0.0f, 0.0f, 0.0f),  // emitter position
+				0.282f,                           // f32 radius
+				irr::core::vector3df(0.0f, 0.0f, 0.0f),  // initial direction & speed (all set to 0.0f == particles stopped)
+				0, 0,                              // minParticlesPerSecond / maxParticlesPerSecond (Will change in main loop)
+												   // video::SColor(0,0,0,255),      // darkest color
+				irr::video::SColor(0, 0, 0, 0),           // darkest color
+				irr::video::SColor(255, 255, 255, 255),   // brightest color
+				90, 200, 0,                         // min age, max age, angle
+				irr::core::dimension2df(1.0f, 1.0f),  // min size
+				irr::core::dimension2df(1.5f, 1.5f)); // max size
+
+			ps60->setEmitter(em60); // Grabs the emitter
+			em60->drop(); // We can drop it here, without deleting it
+
+			ps60->setParent(nodeDiscoBall1); /// Attach these reflexed lights to the Disco Ball N1 (Match to the same position & rotation)
+			ps60->setScale(irr::core::vector3df(41, 41, 41));
+			ps60->setMaterialFlag(irr::video::EMF_ZWRITE_ENABLE, false);
+			ps60->setMaterialTexture(0, estrela_texture);
+			ps60->setMaterialType(irr::video::EMT_TRANSPARENT_ALPHA_CHANNEL); // Transparent texture.
+			ps60->setMaterialFlag(irr::video::EMF_LIGHTING, true); // Node is affected by LIGHT?
+			ps60->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);
+
+			/// Disabled:
+			em60->setMinParticlesPerSecond(90);
+			em60->setMaxParticlesPerSecond(100);
 		}
 
 	}

--- a/src/client/src/misc/Lighting.cpp
+++ b/src/client/src/misc/Lighting.cpp
@@ -99,6 +99,10 @@ namespace client {
 		irr::scene::IAnimatedMeshSceneNode* nodeDiscoBall1;
 
 		bool created = false;
+		irr::scene::IAnimatedMesh *disco_ball_mesh = smgr->getMesh("resources/meshes/disco_ball.obj");
+		irr::video::ITexture* disco_ball_texture = driver->getTexture("resources/materials/disco_ball.jpg");
+		irr::video::ITexture* reflexes_texture = driver->getTexture("resources/materials/reflexes.jpg");
+		irr::video::ITexture* estrela_texture = driver->getTexture("resources/materials/estrela_squared.png");
 
 		for (glm::ivec2 pos : positions) {
 
@@ -107,7 +111,7 @@ namespace client {
 			}
 
 			if (!created) {
-				nodeDiscoBall1 = smgr->addAnimatedMeshSceneNode(smgr->getMesh("resources/meshes/disco_ball.obj"), parent);
+				nodeDiscoBall1 = smgr->addAnimatedMeshSceneNode(disco_ball_mesh, parent);
 				created = true;
 			}
 
@@ -122,9 +126,9 @@ namespace client {
 			nodeDiscoBall1->setMaterialType(irr::video::EMT_REFLECTION_2_LAYER);       // EMT_REFLECTION_2_LAYER
 
 			for (irr::u32 i = 0; i<nodeDiscoBall1->getMaterialCount(); i++) {
-				nodeDiscoBall1->getMaterial(i).setTexture(0, driver->getTexture("resources/materials/disco_ball.jpg")); // Apply texture to my specified material
+				nodeDiscoBall1->getMaterial(i).setTexture(0, disco_ball_texture); // Apply texture to my specified material
 				nodeDiscoBall1->getMaterial(i).getTextureMatrix(0).setTextureScale(3.0f, 1.0f);   /// Repeat (tile) the texture
-				nodeDiscoBall1->getMaterial(i).setTexture(1, driver->getTexture("resources/materials/reflexes.jpg"));
+				nodeDiscoBall1->getMaterial(i).setTexture(1, reflexes_texture);
 				nodeDiscoBall1->getMaterial(i).getTextureMatrix(1).setTextureScale(0.015f, 0.015f); /// Repeat (tile) the texture
 
 				nodeDiscoBall1->getMaterial(i).Lighting = true;
@@ -169,7 +173,7 @@ namespace client {
 			ps60->setParent(nodeDiscoBall1); /// Attach these reflexed lights to the Disco Ball N1 (Match to the same position & rotation)
 			ps60->setScale(irr::core::vector3df(41, 41, 41));
 			ps60->setMaterialFlag(irr::video::EMF_ZWRITE_ENABLE, false);
-			ps60->setMaterialTexture(0, driver->getTexture("resources/materials/estrela_squared.png"));
+			ps60->setMaterialTexture(0, estrela_texture);
 			ps60->setMaterialType(irr::video::EMT_TRANSPARENT_ALPHA_CHANNEL); // Transparent texture.
 			ps60->setMaterialFlag(irr::video::EMF_LIGHTING, true); // Node is affected by LIGHT?
 			ps60->setMaterialFlag(irr::video::EMF_NORMALIZE_NORMALS, true);

--- a/src/client/src/system/SystemButtonRenderer.cpp
+++ b/src/client/src/system/SystemButtonRenderer.cpp
@@ -20,7 +20,7 @@ void SystemButtonRenderer::setup(irr::scene::ISceneManager* smgr, irr::video::IV
 	this->buttonBlocked = driver->getTexture("resources/materials/buttonBlocked.png");
 	this->buttonArrow = driver->getTexture("resources/materials/buttonArrow.png");
 
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	if (entities.size() == 0) {
 		printf("\nThere does not seem to be any buttons\n");
@@ -68,7 +68,7 @@ void SystemButtonRenderer::setup(irr::scene::ISceneManager* smgr, irr::video::IV
 		}
 
 		else { // Rhythm Based buttons
-			
+
 			// button data
 			auto &buttons = group.buttons;
 
@@ -88,7 +88,7 @@ void SystemButtonRenderer::setup(irr::scene::ISceneManager* smgr, irr::video::IV
 				buttonRend.button->setPosition(
 					irr::core::vector3df(buttons[i].pos.x, 0.0, buttons[i].pos.y));
 
-			
+
 				irr::video::SMaterial &material_button_housing =
 						buttonRend.button_housing->getMaterial(0);
 				material_button_housing.Shininess = 0.5f;
@@ -122,7 +122,7 @@ void SystemButtonRenderer::setup(irr::scene::ISceneManager* smgr, irr::video::IV
 }
 
 void SystemButtonRenderer::setRotation(std::vector<anax::Entity> entities, uint32_t j, uint32_t i, irr::scene::IMeshSceneNode *button, glm::ivec2 pos) {
-	
+
 	//Last button group in level
 	if (j == entities.size() - 1) {
 		return;
@@ -165,7 +165,7 @@ void SystemButtonRenderer::setRotation(std::vector<anax::Entity> entities, uint3
 
 void SystemButtonRenderer::updateButtons(irr::video::IVideoDriver* driver)
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 	for (int i = entities.size() - 1; i >= 0; i--) {
 		auto &entity = entities[i];
 		auto &group = entity.getComponent<tempo::ComponentButtonGroup>();

--- a/src/client/src/system/SystemCombo.cpp
+++ b/src/client/src/system/SystemCombo.cpp
@@ -12,7 +12,7 @@ using tempo::operator>>;
 
 void SystemCombo::advanceBeat()
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (auto &entity : entities) {
 		auto &combo = entity.getComponent<tempo::ComponentCombo>();

--- a/src/client/src/system/SystemRenderHealthBars.cpp
+++ b/src/client/src/system/SystemRenderHealthBars.cpp
@@ -13,7 +13,7 @@ void SystemRenderHealthBars::setup(irr::scene::ISceneManager *smgr)
 	irr::core::dimension2d<irr::f32> size(0.7f, 0.15f);
 	irr::video::SColor               color(255, 0, 255, 0);
 
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (auto &entity : entities) {
 		// auto &health    = entity.getComponent<tempo::ComponentHealth>();
@@ -37,7 +37,7 @@ void SystemRenderHealthBars::update(const glm::ivec2 playerpos)
 	irr::video::SColor colour_green(255, 0, 255, 0);
 	irr::video::SColor colour_red(255, 255, 0, 0);
 
-	auto   entities = getEntities();
+	auto&   entities = getEntities();
 	double scale;
 
 	for (auto &entity : entities) {

--- a/src/client/src/system/SystemRenderSceneNode.cpp
+++ b/src/client/src/system/SystemRenderSceneNode.cpp
@@ -13,7 +13,7 @@ namespace client
 {
 void SystemRenderSceneNode::setup(irr::scene::ISceneManager* smgr, irr::video::IVideoDriver* driver)
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (auto entity : entities) {
 		client::ComponentRenderSceneNode& sn =
@@ -71,7 +71,7 @@ void SystemRenderSceneNode::setup(irr::scene::ISceneManager* smgr, irr::video::I
 
 void SystemRenderSceneNode::update(const glm::ivec2 playerpos)
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (auto entity : entities) {
 		tempo::ComponentStage& s = entity.getComponent<tempo::ComponentStage>();

--- a/src/client/src/system/SystemRenderSpikes.cpp
+++ b/src/client/src/system/SystemRenderSpikes.cpp
@@ -40,12 +40,24 @@ void SystemRenderSpikes::setup(irr::scene::ISceneManager *smgr, irr::video::IVid
 	}
 }
 
-void SystemRenderSpikes::updateSpikes(irr::video::IVideoDriver *driver)
+void SystemRenderSpikes::updateSpikes(irr::video::IVideoDriver *driver, const glm::ivec2 playerpos)
 {
 	auto entities = getEntities();
 	for (auto entity : entities) {
 		auto &comp = entity.getComponent<tempo::ComponentSpikes>();
 		auto &rend  = entity.getComponent<client::ComponentRenderSpikes>();
+
+		for (uint32_t i = 0; i<comp.spike_positions.size(); i++) {
+			glm::ivec2 pos = comp.spike_positions[i];
+
+			if (pos.x < playerpos.x - 24 || pos.x > playerpos.x + 7 ||
+			    pos.y < playerpos.y - 33 || pos.y > playerpos.y + 33)
+			{
+				rend.spikes[i].spikeNode->setVisible(false);
+				continue;
+			}
+			rend.spikes[i].spikeNode->setVisible(true);
+		}
 
 		if (comp.isTriggered) {
 			for (uint32_t i = 0; i<comp.spike_positions.size(); i++) {

--- a/src/client/src/system/SystemRenderSpikes.cpp
+++ b/src/client/src/system/SystemRenderSpikes.cpp
@@ -56,21 +56,14 @@ void SystemRenderSpikes::updateSpikes(irr::video::IVideoDriver *driver, const gl
 				rend.spikes[i].spikeNode->setVisible(false);
 				continue;
 			}
-			rend.spikes[i].spikeNode->setVisible(true);
+
+			if (comp.isTriggered) {
+				rend.spikes[i].spikeNode->setVisible(true);
+			} else {
+				rend.spikes[i].spikeNode->setVisible(false);
+			}
 		}
 
-		if (comp.isTriggered) {
-			for (uint32_t i = 0; i<comp.spike_positions.size(); i++) {
-				rend.spikes[i].spikeNode->setPosition(irr::core::vector3df(
-					comp.spike_positions[i].x, 0.0, comp.spike_positions[i].y));
-			}
-		}
-		else {
-			for (uint32_t i = 0; i<comp.spike_positions.size(); i++) {
-				rend.spikes[i].spikeNode->setPosition(irr::core::vector3df(
-					comp.spike_positions[i].x, -2.0f, comp.spike_positions[i].y));
-			}
-		}
 	}
 }
 }  // namespace client

--- a/src/client/src/system/SystemRenderSpikes.cpp
+++ b/src/client/src/system/SystemRenderSpikes.cpp
@@ -14,7 +14,7 @@ namespace client
 {
 void SystemRenderSpikes::setup(irr::scene::ISceneManager *smgr, irr::video::IVideoDriver *driver)
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 	irr::scene::IMesh *spike_mesh = smgr->getMesh("resources/meshes/spikes.obj");
 
 	for (auto &entity : entities) {
@@ -42,7 +42,7 @@ void SystemRenderSpikes::setup(irr::scene::ISceneManager *smgr, irr::video::IVid
 
 void SystemRenderSpikes::updateSpikes(irr::video::IVideoDriver *driver, const glm::ivec2 playerpos)
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 	for (auto entity : entities) {
 		auto &comp = entity.getComponent<tempo::ComponentSpikes>();
 		auto &rend  = entity.getComponent<client::ComponentRenderSpikes>();

--- a/src/client/src/system/SystemRenderSpikes.cpp
+++ b/src/client/src/system/SystemRenderSpikes.cpp
@@ -15,6 +15,7 @@ namespace client
 void SystemRenderSpikes::setup(irr::scene::ISceneManager *smgr, irr::video::IVideoDriver *driver)
 {
 	auto entities = getEntities();
+	irr::scene::IMesh *spike_mesh = smgr->getMesh("resources/meshes/spikes.obj");
 
 	for (auto &entity : entities) {
 		auto &spikes = entity.getComponent<tempo::ComponentSpikes>();
@@ -23,8 +24,6 @@ void SystemRenderSpikes::setup(irr::scene::ISceneManager *smgr, irr::video::IVid
 		auto &positions = spikes.spike_positions;
 
 		for (uint32_t i=0; i<positions.size(); i++) {
-
-			irr::scene::IMesh *spike_mesh = smgr->getMesh("resources/meshes/spikes.obj");
 
 			SpikeNode spikeNode;
 			spikeNode.spikeNode = smgr->addMeshSceneNode(spike_mesh, 0);

--- a/src/client/src/system/SystemStageRenderer.cpp
+++ b/src/client/src/system/SystemStageRenderer.cpp
@@ -152,8 +152,8 @@ void SystemStageRenderer::AnimateTiles(float dt, glm::ivec2 playerpos)
 		tile_t tile = it.second;
 		const glm::ivec2 pos = tile.pos;
 
-		if (pos.x < playerpos.x - 30 || pos.x > playerpos.x + 13 ||
-		    pos.y < playerpos.y - 30 || pos.y > playerpos.y + 30) {
+		if (pos.x < playerpos.x - 24 || pos.x > playerpos.x + 7 ||
+		    pos.y < playerpos.y - 33 || pos.y > playerpos.y + 33) {
 				continue;
 		}
 
@@ -169,7 +169,7 @@ void SystemStageRenderer::AnimateTiles(float dt, glm::ivec2 playerpos)
 		if (tile.height != tile.height_target)
 		{
 			float gap = tile.height_target - tile.height;
-			float delta = 5 * (gap / fabs(gap)) * dt / 1.5f; //1.5 seconds to collapse
+			float delta = 5.f * (gap / fabs(gap)) * dt / 1.5f; //1.5 seconds to collapse
 			if (fabs(delta) > fabs(gap))
 			{
 				delta = gap;

--- a/src/client/src/system/SystemStageRenderer.cpp
+++ b/src/client/src/system/SystemStageRenderer.cpp
@@ -264,6 +264,11 @@ void SystemStageRenderer::Update(irr::scene::ISceneManager *smgr,
 			tileMap[pos].height += delta;
 		}
 
+		if (tile.height >= 5) {
+			batchMesh->addMesh(walls, irr::core::vector3df(pos.x, tile.height, pos.y));
+			continue;
+		}
+
 		bool render;
 		switch (step) {
 		case 0:
@@ -297,11 +302,6 @@ void SystemStageRenderer::Update(irr::scene::ISceneManager *smgr,
 		else{
 			setTileColor(pos, C2);
 			//continue;
-		}
-
-		if (tile.height >= 5) {
-			batchMesh->addMesh(walls, irr::core::vector3df(pos.x, tile.height, pos.y));
-			continue;
 		}
 
 		if (meshMap.find(tile.color) == meshMap.end())

--- a/src/client/src/system/SystemStageRenderer.cpp
+++ b/src/client/src/system/SystemStageRenderer.cpp
@@ -73,7 +73,7 @@ void SystemStageRenderer::setup(irr::scene::ISceneManager *smgr, irr::video::IVi
 {
 	printf("SystemStageRenderer initializing\n");
 
-	auto  entities = getEntities();
+	auto&  entities = getEntities();
 	auto  entity   = std::begin(entities);
 	auto &stage    = entity->getComponent<tempo::ComponentStage>();
 

--- a/src/client/src/system/SystemStageRenderer.cpp
+++ b/src/client/src/system/SystemStageRenderer.cpp
@@ -140,22 +140,22 @@ void SystemStageRenderer::colorStage(int                step,
 	}
 }
 
-void SystemStageRenderer::AnimateTiles(float dt)
+void SystemStageRenderer::AnimateTiles(float dt, glm::ivec2 playerpos)
 {
-	//std::clock_t    start;
-
-
 
 	auto &entities = getEntities();
 	auto  entity   = std::begin(entities);
 	auto &stage    = entity->getComponent<tempo::ComponentStage>();
 
-	//	start = std::clock();
-
 	for (auto& it : tileMap)
 	{
 		tile_t tile = it.second;
-		glm::ivec2 pos = tile.pos;
+		const glm::ivec2 pos = tile.pos;
+
+		if (pos.x < playerpos.x - 30 || pos.x > playerpos.x + 13 ||
+		    pos.y < playerpos.y - 30 || pos.y > playerpos.y + 30) {
+				continue;
+		}
 
 		if ((*stage.heightDelta).find(pos) != (*stage.heightDelta).end())
 		{
@@ -177,7 +177,6 @@ void SystemStageRenderer::AnimateTiles(float dt)
 			tileMap[pos].height += delta;
 		}
 	}
-	//std::cout << "Time: " << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) << " ms" << std::endl;
 
 }
 

--- a/src/client/src/system/SystemStageRenderer.cpp
+++ b/src/client/src/system/SystemStageRenderer.cpp
@@ -217,6 +217,108 @@ void SystemStageRenderer::Update(irr::scene::ISceneManager *smgr,
 	batchMesh->drop();
 }
 
+void SystemStageRenderer::Update(irr::scene::ISceneManager *smgr,
+                                 irr::video::IVideoDriver * driver,
+                                 glm::ivec2                 playerpos,
+                                 irr::video::SColor         C1,
+                                 irr::video::SColor         C2,
+                                 int                        step,
+                                 float                      dt)
+{
+	batchMesh = new irr::scene::CBatchingMesh();
+	irr::scene::ISceneNode *par = this->node->getParent();
+	par->removeChild(this->node);
+
+	auto &entities = getEntities();
+	auto  entity   = std::begin(entities);
+	auto &stage    = entity->getComponent<tempo::ComponentStage>();
+
+
+	for (auto& it : tileMap)
+	{
+		tile_t tile = it.second;
+		glm::ivec2 pos = tile.pos;
+
+		if (pos.x < playerpos.x - 24 || pos.x > playerpos.x + 7 || pos.y < playerpos.y - 33
+		    || pos.y > playerpos.y + 33) {
+			continue;
+		}
+
+		if ((*stage.heightDelta).find(pos) != (*stage.heightDelta).end())
+		{
+			if ((*stage.heightDelta)[pos])
+			{
+				tileMap[pos].height_target = stage.getHeight(pos);
+				(*stage.heightDelta)[pos] = false;
+			}
+		}
+
+		if (tile.height != tile.height_target)
+		{
+			float gap = tile.height_target - tile.height;
+			float delta = 5.f * (gap / fabs(gap)) * dt / 1.5f; //1.5 seconds to collapse
+			if (fabs(delta) > fabs(gap))
+			{
+				delta = gap;
+			}
+			tileMap[pos].height += delta;
+		}
+
+		bool render;
+		switch (step) {
+		case 0:
+		case 1:
+		case 2:
+		case 3:
+		case 9:
+		case 10:
+		case 11:
+		case 12: render = checkerBoardPattern(pos, step); break;
+		case 4:
+		case 5:
+		case 6:
+		case 7:
+		case 8: render = linePattern(0, 5, pos, step - 4); break;
+		case 13:
+		case 14:
+		case 15:
+		case 16:
+		case 17: render = linePattern(1, 5, pos, step - 13); break;
+		case 18:
+		case 19:
+		case 20:
+		case 21: render = squarePattern(1, 12, pos, step); break;
+		}
+
+		if (render) {
+			setTileColor(pos, C1);
+			//continue;
+		}
+		else{
+			setTileColor(pos, C2);
+			//continue;
+		}
+
+		if (tile.height >= 5) {
+			batchMesh->addMesh(walls, irr::core::vector3df(pos.x, tile.height, pos.y));
+			continue;
+		}
+
+		if (meshMap.find(tile.color) == meshMap.end())
+		{
+			initColorMesh(tile.color, smgr);
+		}
+		batchMesh->addMesh(meshMap[tile.color], irr::core::vector3df(pos.x, tile.height, pos.y));
+	}
+
+	batchMesh->update();
+	batchMesh->finalize();
+	this->node = smgr->addMeshSceneNode(batchMesh, 0);
+	batchMesh->drop();
+}
+
+
+
 inline bool SystemStageRenderer::checkerBoardPattern(glm::ivec2 pos, int step)
 {
 	return (pos.x % 2 == pos.y % 2) ^ (step % 2);

--- a/src/client/src/system/SystemStageRenderer.cpp
+++ b/src/client/src/system/SystemStageRenderer.cpp
@@ -11,6 +11,9 @@
 #include <glm/vec4.hpp>
 #include <iostream>
 #include <vector>
+#include <ctime>
+#include <iostream>
+
 
 namespace client
 {
@@ -139,10 +142,15 @@ void SystemStageRenderer::colorStage(int                step,
 
 void SystemStageRenderer::AnimateTiles(float dt)
 {
-	auto  entities = getEntities();
+	//std::clock_t    start;
+
+
+
+	auto &entities = getEntities();
 	auto  entity   = std::begin(entities);
 	auto &stage    = entity->getComponent<tempo::ComponentStage>();
-	auto tiles = stage.getHeights();
+
+	//	start = std::clock();
 
 	for (auto& it : tileMap)
 	{
@@ -169,6 +177,8 @@ void SystemStageRenderer::AnimateTiles(float dt)
 			tileMap[pos].height += delta;
 		}
 	}
+	//std::cout << "Time: " << (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000) << " ms" << std::endl;
+
 }
 
 void SystemStageRenderer::Update(irr::scene::ISceneManager *smgr,

--- a/src/lib-tempo/include/tempo/component/ComponentStage.hpp
+++ b/src/lib-tempo/include/tempo/component/ComponentStage.hpp
@@ -8,7 +8,7 @@
 #include <glm/fwd.hpp>
 #include <glm/vec2.hpp>
 #include <vector>
-
+#include <unordered_map>
 #include <tuple>
 
 namespace tempo
@@ -35,20 +35,36 @@ struct vec2less
 	}
 };
 
+struct vec2eq
+{
+    size_t operator()(const glm::ivec2& k)const
+    {
+        return std::hash<int>()(k.x) ^ std::hash<int>()(k.y);
+    }
+
+    bool operator()(const glm::ivec2& a, const glm::ivec2& b)const
+    {
+            return a.x == b.x && a.y == b.y;
+    }
+};
+
+
 template< typename tPair >
 struct second_t {
 	typename tPair::second_type operator()( const tPair& p ) const { return p.second; }
 };
 
-typedef std::map<glm::ivec2,
-                stage_tile,
-                vec2less,
-                std::allocator<std::pair<const glm::ivec2, stage_tile>>> tileMap;
+typedef std::unordered_map<glm::ivec2,
+                           stage_tile,
+                           vec2eq,
+                           vec2eq,
+                           std::allocator<std::pair<const glm::ivec2, stage_tile>>> tileMap;
 
-typedef std::map<glm::ivec2,
-                bool,
-                vec2less,
-                std::allocator<std::pair<const glm::ivec2, stage_tile>>> heightDeltaMap;
+typedef std::unordered_map<glm::ivec2,
+                          bool,
+                          vec2eq,
+                          vec2eq,
+                          std::allocator<std::pair<const glm::ivec2, stage_tile>>> heightDeltaMap;
 
 extern tileMap _global_stage;
 extern heightDeltaMap _global_heightDelta;

--- a/src/lib-tempo/src/component/ComponentStage.cpp
+++ b/src/lib-tempo/src/component/ComponentStage.cpp
@@ -50,6 +50,8 @@ void ComponentStage::loadLevel(const char *stage_file)
 		return;
 	}
 
+	_global_stage.reserve(height*width);
+
 	// Load the new tiles
 	for (int y = 0; y < height; y++) {
 		if(y > fheight * feeder_areas){
@@ -130,9 +132,10 @@ bool ComponentStage::existstTile(glm::ivec2 position)
 
 bool ComponentStage::isNavigable(glm::ivec2 position)
 {
-	if (existstTile(position))
+	auto itr = (*tiles).find(position);
+	if (itr == (*tiles).end())
 	{
-		return getHeight(position) < 5;
+		return itr->second.height < 5;
 	}
 	return false;
 }

--- a/src/lib-tempo/src/system/SystemHealth.cpp
+++ b/src/lib-tempo/src/system/SystemHealth.cpp
@@ -9,7 +9,7 @@ namespace tempo
 
 void SystemHealth::check_health()
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (auto &entity : entities) {
 		auto &h = entity.getComponent<ComponentHealth>();
@@ -54,7 +54,7 @@ void SystemHealth::check_health()
 
 void SystemHealth::broadcastHealth()
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (auto &entity : entities)
 	{
@@ -97,7 +97,7 @@ void SystemHealth::client_receiveHealth(anax::World &world)
 
 void SystemHealth::regenerate()
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (auto &entity : entities)
 	{

--- a/src/lib-tempo/src/system/SystemTrigger.cpp
+++ b/src/lib-tempo/src/system/SystemTrigger.cpp
@@ -33,7 +33,7 @@ void SystemTrigger::updateButtons(anax::World& world)
 	untriggerPos.clear();
 
 	// get all the button groups
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (uint32_t i = 0; i < entities.size(); i++) {
 
@@ -177,7 +177,7 @@ void SystemTrigger::updateButtons(anax::World& world)
 				button_group.action_happened = true;
 
 				for (auto& entity : entities) {
-					
+
 					auto &tempGroup = entity.getComponent<tempo::ComponentButtonGroup>();
 					int rhythmID = tempGroup.rhythmID;
 
@@ -221,7 +221,7 @@ void SystemTrigger::updateButtons(anax::World& world)
 
 void SystemTrigger::resetButtons(int rhythmID) {
 
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (uint32_t i = 0; i < entities.size(); i++) {
 		auto &entity = entities[i];
@@ -256,7 +256,7 @@ void SystemTrigger::resetButtons(int rhythmID) {
 
 void SystemTrigger::blockButtons(int rhythmID) {
 
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (uint32_t i = 0; i < entities.size(); i++) {
 		auto &entity = entities[i];
@@ -284,8 +284,8 @@ void SystemTrigger::blockButtons(int rhythmID) {
 std::vector<glm::ivec2> SubSystemGetPlayers::getPlayers()
 {
 	std::vector<glm::ivec2> currentPlayerPos;
-	
-	auto entities = getEntities();
+
+	auto& entities = getEntities();
 
 	// Get all the players and save their locations
 	for (auto& entity : entities) {
@@ -302,7 +302,7 @@ std::vector<glm::ivec2> SubSystemGetPlayers::getPlayers()
 
 void SubSystemUpdateSpikes::updateSpikes(std::vector<glm::ivec2> untriggerPos)
 {
-	auto entities = getEntities();
+	auto& entities = getEntities();
 
 	for (auto &entity : entities) {
 


### PR DESCRIPTION
Optimisations for when we load many spikes and disco balls:
-> load textures and meshes just once

Algorithmic optimisations for when we have a high number of tiles:
-> using a hash_map instead of a normal map, which is implemented as a binary tree