### PR TITLE
Only nudge if beat has been missed

### DIFF
--- a/src/client/src/system/SystemRenderGUI.cpp
+++ b/src/client/src/system/SystemRenderGUI.cpp
@@ -179,11 +179,13 @@ void SystemRenderGUI::updateNudge(irr::gui::IGUIFont *font,
 	// by in relation to the beat per beat
 	float drift = beat_length - avg_key_delta;
 
-	if(drift > 0 && avg_beat_delta + drift * 5 > window_size){
-		msg = "Too fast!";
-	}
-	if(drift < 0 && avg_beat_delta + drift * 5 < -window_size){
-		msg = "Too slow!";
+	if(beats_missed > 0){
+		if(drift > 0 && avg_beat_delta + drift * 5 > window_size){
+			msg = "Too fast!";
+		}
+		if(drift < 0 && avg_beat_delta + drift * 5 < -window_size){
+			msg = "Too slow!";
+		}
 	}
 
 	if(msg != nullptr){


### PR DESCRIPTION
As per (maybe popular) request this ensures that the "too fast" and "too slow" text is only shown if the player has missed a beat recently (within the last 5 beats).

Don't know what the consensus is on this change, but here it is if wanted.